### PR TITLE
fix: loop initial var only allowed in C99 mode while apply patch

### DIFF
--- a/patches/nginx.patch
+++ b/patches/nginx.patch
@@ -11,6 +11,8 @@ index 104e8daf7..9f5200c91 100644
 +ngx_SSL_client_features(ngx_connection_t *c) {
 +
 +    SSL                           *s = NULL;
++    size_t                        i,j;
++    int                           index;
 +
 +    if (c == NULL) {
 +        return NGX_ERROR;
@@ -35,7 +37,7 @@ index 104e8daf7..9f5200c91 100644
 +        }
 +
 +        // Convert each cipher suite to a hexadecimal string and store it
-+        for (size_t i = 0; i < c->ssl->ciphers_sz; i++) {
++        for (i = 0; i < c->ssl->ciphers_sz; i++) {
 +            const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
 +            if (cipher == NULL) {
 +                return NGX_ERROR; // Handle error
@@ -59,7 +61,7 @@ index 104e8daf7..9f5200c91 100644
 +            c->ssl->ciphers[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
 +            if (c->ssl->ciphers[i] == NULL) {
 +                // Handle allocation failure and clean up previously allocated memory
-+                for (size_t j = 0; j < i; j++) {
++                for (j = 0; j < i; j++) {
 +                    ngx_pfree(c->pool, c->ssl->ciphers[j]);
 +                }
 +                ngx_pfree(c->pool, c->ssl->ciphers);
@@ -80,30 +82,30 @@ index 104e8daf7..9f5200c91 100644
 +            return NGX_ERROR;
 +        }
 +
-+        for (int i = 0; i < num_sigalgs; ++i) {
++        for (index = 0; index < num_sigalgs; ++index) {
 +            int psign, phash, psignhash;
 +            unsigned char rsig, rhash;
-+            SSL_get_sigalgs(s, i, &psign, &phash, &psignhash, &rsig, &rhash);
++            SSL_get_sigalgs(s, index, &psign, &phash, &psignhash, &rsig, &rhash);
 +
 +            // Format as a hexadecimal string
 +            char hex_string[5]; // Enough for "XXXX" + null terminator
 +            snprintf(hex_string, sizeof(hex_string), "%02x%02x", rhash, rsig);
 +
 +            // Allocate memory for the hex string
-+            sigalgs_hex_strings[i] = ngx_pnalloc(c->pool, sizeof(hex_string));
-+            if (sigalgs_hex_strings[i] == NULL) {
++            sigalgs_hex_strings[index] = ngx_pnalloc(c->pool, sizeof(hex_string));
++            if (sigalgs_hex_strings[index] == NULL) {
 +                ngx_log_error(NGX_LOG_ERR, c->log, 0, "Failed to allocate memory for a signature algorithm hex string");
 +                return NGX_ERROR;
 +            }
 +
 +            // Copy the hex string into allocated memory
-+            ngx_memcpy(sigalgs_hex_strings[i], hex_string, sizeof(hex_string));
++            ngx_memcpy(sigalgs_hex_strings[index], hex_string, sizeof(hex_string));
 +        }
 +
 +        // Save the array of hex strings to your struct
 +        c->ssl->sigalgs_hash_values = sigalgs_hex_strings;
 +    }
-+    
++
 +    c->ssl->sigalgs_sz = num_sigalgs;
 +    return NGX_OK;
 +}
@@ -113,7 +115,7 @@ index 104e8daf7..9f5200c91 100644
 +
 +    int                            got_extensions;
 +    int                           *ext_out;
-+    size_t                         ext_len;
++    size_t                         ext_len, i, j;
 +    ngx_connection_t              *c;
 +
 +    c = arg;
@@ -144,15 +146,15 @@ index 104e8daf7..9f5200c91 100644
 +
 +    c->ssl->extensions = ngx_palloc(c->pool, sizeof(char *) * ext_len);
 +    if (c->ssl->extensions != NULL) {
-+        for (size_t i = 0; i < ext_len; i++) {
++        for (i = 0; i < ext_len; i++) {
 +            char hex_str[6];  // Buffer to hold the hexadecimal string (4 digits + null terminator)
 +            snprintf(hex_str, sizeof(hex_str), "%04x", ext_out[i]);
-+            
++
 +            // Allocate memory for the hex string and copy it
 +            c->ssl->extensions[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
 +            if (c->ssl->extensions[i] == NULL) {
 +                // Handle allocation failure and clean up previously allocated memory
-+                for (size_t j = 0; j < i; j++) {
++                for (j = 0; j < i; j++) {
 +                    ngx_pfree(c->pool, c->ssl->extensions[j]);
 +                }
 +                ngx_pfree(c->pool, c->ssl->extensions);
@@ -164,7 +166,7 @@ index 104e8daf7..9f5200c91 100644
 +        c->ssl->extensions_sz = ext_len;
 +    }
 +
-+    for (size_t i = 0; i < ext_len; i++) {
++    for (i = 0; i < ext_len; i++) {
 +        ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0, "c->ssl->extensions[%zu] = %s", i, c->ssl->extensions[i]);
 +    }
 +

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -80,7 +80,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
 {
     // this function sets stuff on the ja4 struct so the fingerprint can easily, and clearly be formed in a separate function
     SSL *ssl;
-    size_t i;
+    size_t i, j;
     size_t len = 0;
 
     if (!c->ssl)
@@ -180,7 +180,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
             if (ja4->ciphers[ja4->ciphers_sz] == NULL)
             {
                 // Handle allocation failure and clean up previously allocated memory
-                for (size_t j = 0; j < ja4->ciphers_sz; j++)
+                for (j = 0; j < ja4->ciphers_sz; j++)
                 {
                     ngx_pfree(pool, ja4->ciphers[j]);
                 }
@@ -267,7 +267,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
                     if (ja4->extensions[ja4->extensions_sz] == NULL)
                     {
                         // Handle allocation failure and clean up previously allocated memory
-                        for (size_t j = 0; j < ja4->extensions_sz; j++)
+                        for (j = 0; j < ja4->extensions_sz; j++)
                         {
                             ngx_pfree(pool, ja4->extensions[j]);
                         }
@@ -292,7 +292,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
                     if (ja4->extensions_no_psk[ja4->extensions_no_psk_count] == NULL)
                     {
                         // Handle allocation failure and clean up previously allocated memory
-                        for (size_t j = 0; j < ja4->extensions_no_psk_count; j++)
+                        for (j = 0; j < ja4->extensions_no_psk_count; j++)
                         {
                             ngx_pfree(pool, ja4->extensions_no_psk[j]);
                         }
@@ -332,7 +332,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
             if (ja4->sigalgs[ja4->sigalgs_sz] == NULL)
             {
                 // Handle allocation failure and clean up previously allocated memory
-                for (size_t j = 0; j < ja4->sigalgs_sz; j++)
+                for (j = 0; j < ja4->sigalgs_sz; j++)
                 {
                     ngx_pfree(pool, ja4->sigalgs[j]);
                 }
@@ -563,9 +563,9 @@ void ngx_ssl_ja4_fp_string(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4, ngx_str_t *out)
 {
     // This function calculates the ja4 fingerprint but it doesn't hash extensions and ciphers
     // Instead, it just comma separates them
-
+    size_t i;
     char **sigalgs_copy = malloc(ja4->sigalgs_sz * sizeof(char *));
-    for (size_t i = 0; i < ja4->sigalgs_sz; ++i)
+    for (i = 0; i < ja4->sigalgs_sz; ++i)
     {
         sigalgs_copy[i] = strdup(ja4->sigalgs[i]);
     }
@@ -575,15 +575,15 @@ void ngx_ssl_ja4_fp_string(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4, ngx_str_t *out)
     // alpn (2 chars), separators ('_' x3), null-terminator
     size_t len = 1 + 2 + 1 + 2 + 2 + 2 + 3 + 1;
     // Dynamic size for variable elements: ciphers, extensions, signature algorithms
-    for (size_t i = 0; i < ja4->ciphers_sz; ++i)
+    for (i = 0; i < ja4->ciphers_sz; ++i)
     {
         len += strlen(ja4->ciphers[i]) + 1; // strlen of cipher + comma
     }
-    for (size_t i = 0; i < ja4->extensions_sz; ++i)
+    for (i = 0; i < ja4->extensions_sz; ++i)
     {
         len += strlen(ja4->extensions[i]) + 1; // strlen of extension + comma
     }
-    for (size_t i = 0; i < ja4->sigalgs_sz; ++i)
+    for (i = 0; i < ja4->sigalgs_sz; ++i)
     {
         len += strlen(ja4->sigalgs[i]) + 1; // strlen of sigalg + comma
     }
@@ -656,7 +656,7 @@ void ngx_ssl_ja4_fp_string(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4, ngx_str_t *out)
     // Add ciphers
     if (ja4->ciphers_sz > 0)
     {
-        for (size_t i = 0; i < ja4->ciphers_sz; ++i)
+        for (i = 0; i < ja4->ciphers_sz; ++i)
         {
             size_t n = ngx_snprintf(out->data + cur, strlen(ja4->ciphers[i]) + 2, "%s,", ja4->ciphers[i]) - out->data - cur;
             cur += n;
@@ -670,7 +670,7 @@ void ngx_ssl_ja4_fp_string(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4, ngx_str_t *out)
     // Add extensions
     if (ja4->extensions_sz > 0)
     {
-        for (size_t i = 0; i < ja4->extensions_sz; ++i)
+        for (i = 0; i < ja4->extensions_sz; ++i)
         {
             size_t n = ngx_snprintf(out->data + cur, strlen(ja4->extensions[i]) + 2, "%s,", ja4->extensions[i]) - out->data - cur;
             cur += n;
@@ -682,7 +682,7 @@ void ngx_ssl_ja4_fp_string(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4, ngx_str_t *out)
     if (ja4->sigalgs_sz > 0)
     {
         out->data[cur++] = '_'; // Add separator only if signature algorithms are present
-        for (size_t i = 0; i < ja4->sigalgs_sz; ++i)
+        for (i = 0; i < ja4->sigalgs_sz; ++i)
         {
             size_t n = ngx_snprintf(out->data + cur, strlen(sigalgs_copy[i]) + 2, "%s,", sigalgs_copy[i]) - out->data - cur;
             cur += n;
@@ -690,7 +690,7 @@ void ngx_ssl_ja4_fp_string(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4, ngx_str_t *out)
         cur--; // Remove the trailing comma
     }
 
-    for (size_t i = 0; i < ja4->sigalgs_sz; ++i)
+    for (i = 0; i < ja4->sigalgs_sz; ++i)
     {
         free(sigalgs_copy[i]);
     }
@@ -1327,7 +1327,7 @@ void ngx_ssl_ja4l_fp(ngx_pool_t *pool, ngx_ssl_ja4l_t *ja4l, ngx_str_t *out)
     const size_t max_hop_count_len = 3; // uint8_t max is 255, which is 3 characters
 
     // init stuff
-    double propagation_delay_factor; // Declare the variable to store the propagation delay factor
+    double propagation_delay_factor = 1.0; // Declare the variable to store the propagation delay factor
     uint8_t initial_ttl;
 
     // Include space for 2 underscores and the null-terminator


### PR DESCRIPTION
‘for’ loop initial declarations are only allowed in C99 mode while in apply patch.
double propagation_delay_factor not initial