### PR TITLE
Fix incorrect TLS version in JA4 fingerprint

### DIFF
--- a/patches/nginx.patch
+++ b/patches/nginx.patch
@@ -1,8 +1,8 @@
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index 104e8daf7..9f5200c91 100644
+index 104e8daf7..e0c46d21a 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
-@@ -1759,6 +1759,173 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+@@ -1759,6 +1759,210 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
  }
  
  
@@ -114,6 +114,16 @@ index 104e8daf7..9f5200c91 100644
 +    int                            got_extensions;
 +    int                           *ext_out;
 +    size_t                         ext_len;
++
++    // Declare the highest client TLS protocol version
++    int                            highest_supported_tls_client_version;
++
++    const unsigned char           *supported_versions_ext;
++    size_t                         supported_versions_ext_len;
++
++    const unsigned char           *supported_versions;
++    size_t                         supported_versions_len;
++
 +    ngx_connection_t              *c;
 +
 +    c = arg;
@@ -147,7 +157,34 @@ index 104e8daf7..9f5200c91 100644
 +        for (size_t i = 0; i < ext_len; i++) {
 +            char hex_str[6];  // Buffer to hold the hexadecimal string (4 digits + null terminator)
 +            snprintf(hex_str, sizeof(hex_str), "%04x", ext_out[i]);
-+            
++
++            // Check for the supported_versions extension (0x002b) in the ClientHello
++            if (ext_out[i] == 0x002b) {
++                ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "Found supported_versions extension (0x002b)");
++
++                if (SSL_client_hello_get0_ext(s, 0x002b, &supported_versions_ext, &supported_versions_ext_len)) {
++
++                    // Skip the first byte as it denotes the length of the list
++                    supported_versions_len = supported_versions_ext_len - 1;
++
++                    supported_versions = supported_versions_ext + 1;
++                    highest_supported_tls_client_version = 0;
++
++                    // Extracts and constructs SSL/TLS versions from supported_versions array
++                    for (size_t j = 0; j + 1 < supported_versions_len; j += 2) {
++                        int version = (supported_versions[j] << 8) | supported_versions[j + 1];
++
++                        if (version > highest_supported_tls_client_version) {
++                            highest_supported_tls_client_version = version;
++                        }
++                    }
++
++                    // Set highest supported TLS version for JA4 module
++                    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "Highest TLS protocol version found: %d", highest_supported_tls_client_version);
++                    c->ssl->highest_supported_tls_client_version = highest_supported_tls_client_version;
++                }
++            }
++
 +            // Allocate memory for the hex string and copy it
 +            c->ssl->extensions[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
 +            if (c->ssl->extensions[i] == NULL) {
@@ -176,7 +213,7 @@ index 104e8daf7..9f5200c91 100644
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
  {
-@@ -1778,12 +1945,16 @@ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1778,12 +1982,16 @@ ngx_ssl_handshake(ngx_connection_t *c)
  
      ngx_ssl_clear_error(c->log);
  
@@ -196,16 +233,17 @@ index 104e8daf7..9f5200c91 100644
              return NGX_ERROR;
          }
 diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index 860ea26dd..843020703 100644
+index 860ea26dd..da58ed0ad 100644
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
-@@ -120,6 +120,24 @@ struct ngx_ssl_connection_s {
+@@ -120,6 +120,25 @@ struct ngx_ssl_connection_s {
      unsigned                    in_ocsp:1;
      unsigned                    early_preread:1;
      unsigned                    write_blocked:1;
 +
 +    // ja4
 +    int             version;
++    int             highest_supported_tls_client_version;
 +
 +    size_t          ciphers_sz;
 +    char **ciphers;

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -115,15 +115,12 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
     /* SSLVersion*/
     // get string version:
     int client_version_int = SSL_client_version(ssl);
-    int max_version_int = SSL_get_max_proto_version(ssl);
+    int max_version_int = c->ssl->highest_supported_tls_client_version;
     int version_int = 0;
 
-    if (max_version_int > client_version_int)
-    {
+    if (max_version_int) {
         version_int = max_version_int;
-    }
-    else
-    {
+    } else {
         version_int = client_version_int;
     }
 

--- a/src/ngx_http_ssl_ja4_module.h
+++ b/src/ngx_http_ssl_ja4_module.h
@@ -6,6 +6,7 @@
 typedef struct ngx_ssl_ja4_s
 {
     char *version; // TLS version
+    char *highest_supported_tls_client_version;
 
     unsigned char transport; // 'q' for QUIC, 't' for TCP
 


### PR DESCRIPTION
### Overview

When making a request with a client that uses TLS 1.2, the resulting JA4 fingerprint can sometimes suggest that the client was using TLS 1.3, for example:
```bash
$ curl https://localhost/ -sk \
    --tlsv1.2 \
    --tls-max 1.2 \
    | grep "JA4:"
 
JA4: t13d3705h2_5cdd65e42219_72d5d7dee592
     ^^^ Note: Expected t12 here
```

This PR provides updates to the following files to resolve the issue:
- patches/nginx.patch
- src/ngx_http_ssl_ja4_module(c and h) 

### patches/nginx.patch updates
Additional updates to `ngx_event_openssl` patch to allow nginx to extract the client TLS version from the supported_versions extension (0x002b) when connecting with TLS v1.3.

NOTE: This patch was generated using the updates made under PR (https://github.com/FoxIO-LLC/ja4-nginx/pull/4) within the ja4-nginx repo.

### src/ngx_http_ssl_ja4_module
1. Updated `max_version_int` to use the TLS version provided by the supported_versions extension, instead of `SSL_get_max_proto_version`, as based on our current understanding of the OpenSSL docs, we believe that the `SSL_get_max_proto_version` function sets the max TLS version to the maximum permissible version on the server, not that of the connecting client.

    Supporting doc link: https://docs.openssl.org/3.2/man3/SSL_CTX_get_max_proto_version/

2. Applied changes to logic that is used to set the `version_int` value, so that the client TLS version is set based upon the criteria noted within the JA4 Technical docs.
    
    Supporting doc link: https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4.md#tls-and-dtls-version


### Supporting Information

**Example of updated behaviour (using PR updates)**
Following the above updates, when making a request with a client that uses TLS 1.2 (or earlier) the version should be correctly reflected in the resulting JA4 fingerprint, for example:

```bash
$ curl https://localhost/ -sk \
    --tlsv1.2 \
    --tls-max 1.2 \
    | grep "JA4:"
 
JA4: t12d3705h2_5cdd65e42219_72d5d7dee592
```