### PR TITLE
Fixed incorrect determination of the number of ciphers

### DIFF
--- a/patches/wb-ja4-num-ciphers-error.patch
+++ b/patches/wb-ja4-num-ciphers-error.patch
@@ -1,0 +1,146 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index 0545150ed..52f9bcc4e 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -1705,7 +1705,6 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+     return NGX_OK;
+ }
+ 
+-
+ // adds ciphers to the ssl object for ja4 fingerprint
+ ngx_int_t
+ ngx_SSL_client_features(ngx_connection_t *c) {
+@@ -1717,59 +1716,59 @@ ngx_SSL_client_features(ngx_connection_t *c) {
+     }
+     s = c->ssl->connection;
+ 
+-    /* Cipher suites */
+-    c->ssl->ciphers = NULL;
+-    STACK_OF(SSL_CIPHER) *ciphers = SSL_get_client_ciphers(s);
++    uint8_t  *u_ciphers;
+ 
+-    if (ciphers == NULL) {
+-        return NGX_ERROR; // Handle error
++    int tls_cipher_len = SSL_get0_raw_cipherlist (c->ssl->connection, NULL);
++    if (tls_cipher_len == 0) {
++        return NGX_ERROR;
+     }
+ 
+-    c->ssl->ciphers_sz = sk_SSL_CIPHER_num(ciphers);
+-
+-    if (c->ssl->ciphers_sz) {
+-        // Allocate memory for the array of cipher strings
+-        c->ssl->ciphers = ngx_pnalloc(c->pool, c->ssl->ciphers_sz * sizeof(char *));
+-        if (c->ssl->ciphers == NULL) {
+-            return NGX_ERROR; // Handle allocation failure
+-        }
+-
+-        // Convert each cipher suite to a hexadecimal string and store it
+-        for (size_t i = 0; i < c->ssl->ciphers_sz; i++) {
+-            const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
+-            if (cipher == NULL) {
+-                return NGX_ERROR; // Handle error
+-            }
+-
+-            // Get the two-byte TLS cipher ID in network byte order
+-            unsigned char cipher_id_bytes[2];
+-            cipher_id_bytes[0] = (SSL_CIPHER_get_id(cipher) >> 8) & 0xFF;
+-            cipher_id_bytes[1] = SSL_CIPHER_get_id(cipher) & 0xFF;
++    int len = SSL_get0_raw_cipherlist (c->ssl->connection, &u_ciphers);
++    len /= tls_cipher_len;
++    if (len == 0) {
++        return NGX_ERROR;
++    }
+ 
+-            const SSL_CIPHER *found_cipher = SSL_CIPHER_find(s, cipher_id_bytes);
+-            if (found_cipher == NULL) {
+-                return NGX_ERROR; // Handle error
+-            }
++    c->ssl->ciphers = ngx_pnalloc (c->pool, len * sizeof(char *));
++    if (c->ssl->ciphers == NULL) {
++        return NGX_ERROR;
++    }
+ 
+-            // Convert the cipher ID to a hexadecimal string
+-            char hex_str[6]; // Buffer to hold the hexadecimal string (4 digits + null terminator)
+-            snprintf(hex_str, sizeof(hex_str), "%02x%02x", cipher_id_bytes[0], cipher_id_bytes[1]);
++    c->ssl->ciphers_sz = 0;
++    for (int i = 0; i < len; i++) {
++        const SSL_CIPHER  *cipher = SSL_CIPHER_find(c->ssl->connection, u_ciphers + i * tls_cipher_len);
+ 
+-            // Allocate memory for the hex string and copy it
+-            c->ssl->ciphers[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
+-            if (c->ssl->ciphers[i] == NULL) {
+-                // Handle allocation failure and clean up previously allocated memory
+-                for (size_t j = 0; j < i; j++) {
+-                    ngx_pfree(c->pool, c->ssl->ciphers[j]);
+-                }
+-                ngx_pfree(c->pool, c->ssl->ciphers);
+-                c->ssl->ciphers = NULL;
+-                return NGX_ERROR;
++        if (!cipher) {
++            continue; // Probably - GREASE value
++        }
++        uint16_t id = SSL_CIPHER_get_id (cipher) & 0xffff;
++        /*
++         * Convert the cipher ID to a hexadecimal string Buffer to
++         * hold the hexadecimal string (4 digits + null terminator)
++         **/
++        char hex_str[5];
++        snprintf (hex_str, sizeof(hex_str), "%04x", id);
++        /* Allocate memory for the hex string and copy it */
++        c->ssl->ciphers [c->ssl->ciphers_sz] = ngx_pnalloc(c->pool, sizeof(hex_str));
++        if (c->ssl->ciphers[c->ssl->ciphers_sz] == NULL) {
++            /* Handle allocation failure */
++            for (size_t j = 0; j < c->ssl->ciphers_sz; j++) {
++                ngx_pfree(c->pool, c->ssl->ciphers[j]);
+             }
+-            ngx_memcpy(c->ssl->ciphers[i], hex_str, sizeof(hex_str));
++            ngx_pfree(c->pool, c->ssl->ciphers);
++            c->ssl->ciphers = NULL;
++            return NGX_ERROR;
+         }
++        ngx_memcpy (c->ssl->ciphers [c->ssl->ciphers_sz], hex_str, sizeof(hex_str));
++        c->ssl->ciphers_sz++;
+     }
+ 
++#if (NGX_DEBUG)
++    ngx_log_debug (NGX_LOG_DEBUG_EVENT, c->log, 0, "ja4: unsorted ciphers_suite:");
++    for (int i = 0; i < (int) c->ssl->ciphers_sz; i++)
++        ngx_log_debug2 (NGX_LOG_DEBUG_EVENT, c->log, 0, "-- [%2d]: %s", i, c->ssl->ciphers[i]);
++#endif
++
+     /* Signature Algorithms */
+     int num_sigalgs = SSL_get_sigalgs(s, 0, NULL, NULL, NULL, NULL, NULL);
+     if (num_sigalgs > 0) {
+@@ -1792,6 +1791,12 @@ ngx_SSL_client_features(ngx_connection_t *c) {
+             // Allocate memory for the hex string
+             sigalgs_hex_strings[i] = ngx_pnalloc(c->pool, sizeof(hex_string));
+             if (sigalgs_hex_strings[i] == NULL) {
++                // Handle allocation failure and clean up previously allocated memory
++                for (int j = 0; j < i; j++) {
++                    ngx_pfree(c->pool, sigalgs_hex_strings[j]);
++                }
++                ngx_pfree(c->pool, sigalgs_hex_strings);
++                sigalgs_hex_strings = NULL;
+                 ngx_log_error(NGX_LOG_ERR, c->log, 0, "Failed to allocate memory for a signature algorithm hex string");
+                 return NGX_ERROR;
+             }
+@@ -1803,7 +1808,7 @@ ngx_SSL_client_features(ngx_connection_t *c) {
+         // Save the array of hex strings to your struct
+         c->ssl->sigalgs_hash_values = sigalgs_hex_strings;
+     }
+-    
++
+     c->ssl->sigalgs_sz = num_sigalgs;
+     return NGX_OK;
+ }
+@@ -1847,7 +1852,7 @@ ngx_SSL_early_cb_fn(SSL *s, int *al, void *arg) {
+         for (size_t i = 0; i < ext_len; i++) {
+             char hex_str[6];  // Buffer to hold the hexadecimal string (4 digits + null terminator)
+             snprintf(hex_str, sizeof(hex_str), "%04x", ext_out[i]);
+-            
++
+             // Allocate memory for the hex string and copy it
+             c->ssl->extensions[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
+             if (c->ssl->extensions[i] == NULL) {


### PR DESCRIPTION
### Description
There is an error in determining the number of ciphers in the suit:
```bash
curl -k --tls-max 1.2 https://127.0.0.1:8443/; echo
```
gives
```bash
            JA4:    t13i2706h2_a2460661a67a_a44c6288192a
            JA4one: t13i2705h2_a2460661a67a_52333a2beb0b
```
but wireshark decode next parameter of `Client TLS Hello`

![Screenshot at 2025-06-27 13-57-09](https://github.com/user-attachments/assets/322c444b-1a79-491c-a40f-cb10a066ff99)

### How to fix?

After applying first patch, necessary applying secondary patch:
```bash
cd <source_of_nginx>
patch -p1 < ../ja4-nginx-module/patches/nginx.patch
patch -p1 < ../ja4-nginx-module/patches/wb-ja4-num-ciphers-error.patch
make -j
```