### PR TITLE
Fixed incorrect tls version detection

### DIFF
--- a/patches/wb-ja4-version-error.patch
+++ b/patches/wb-ja4-version-error.patch
@@ -1,0 +1,37 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index 0545150ed..dd27484df 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -1803,7 +1803,7 @@ ngx_SSL_client_features(ngx_connection_t *c) {
+         // Save the array of hex strings to your struct
+         c->ssl->sigalgs_hash_values = sigalgs_hex_strings;
+     }
+-    
++
+     c->ssl->sigalgs_sz = num_sigalgs;
+     return NGX_OK;
+ }
+@@ -1826,6 +1826,7 @@ ngx_SSL_early_cb_fn(SSL *s, int *al, void *arg) {
+         return 1;
+     }
+ 
++    c->ssl->version = 0;
+     c->ssl->extensions_sz = 0;
+     c->ssl->extensions = NULL;
+     got_extensions = SSL_client_hello_getall_extensions_present(s,
+@@ -1845,9 +1846,13 @@ ngx_SSL_early_cb_fn(SSL *s, int *al, void *arg) {
+     c->ssl->extensions = ngx_palloc(c->pool, sizeof(char *) * ext_len);
+     if (c->ssl->extensions != NULL) {
+         for (size_t i = 0; i < ext_len; i++) {
+-            char hex_str[6];  // Buffer to hold the hexadecimal string (4 digits + null terminator)
++            char hex_str[5];
+             snprintf(hex_str, sizeof(hex_str), "%04x", ext_out[i]);
+-            
++
++            if (ext_out[i] == TLSEXT_TYPE_supported_versions) {
++                c->ssl->version = TLS1_3_VERSION;
++            }
++
+             // Allocate memory for the hex string and copy it
+             c->ssl->extensions[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
+             if (c->ssl->extensions[i] == NULL) {

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -118,14 +118,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
     int max_version_int = SSL_get_max_proto_version(ssl);
     int version_int = 0;
 
-    if (max_version_int > client_version_int)
-    {
-        version_int = max_version_int;
-    }
-    else
-    {
-        version_int = client_version_int;
-    }
+    version_int = (c->ssl->version) ? max_version_int : client_version_int;
 
     switch(version_int)
     {

--- a/src/ngx_http_ssl_ja4_module.h
+++ b/src/ngx_http_ssl_ja4_module.h
@@ -274,7 +274,7 @@ ngx_ssl_ja4_detail_print(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
 
     /* Version */
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT,
-                   pool->log, 0, "ssl_ja4: Version:  %d\n", ja4->version);
+                   pool->log, 0, "ssl_ja4: Version:  %s", ja4->version);
 
     /* Ciphers */
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT,
@@ -368,7 +368,7 @@ ngx_ssl_ja4_detail_print(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
     //                    ja4->alpn_first_value);
     // }
 }
-    
+
 #endif
 
 // FUNCTION PROTOTYPES


### PR DESCRIPTION
### Description
There is an error in determining the TLS protocol version.
```bash
curl -k --tls-max 1.2 https://127.0.0.1:8443/; echo
            JA4:    t12i2706h2_a2460661a67a_a44c6288192a
            JA4one: t12i2705h2_a2460661a67a_52333a2beb0b
            
curl -k --tls-max 1.3 https://127.0.0.1:8443/; echo
            JA4:    t12i3011h2_1d37bd780c83_b26ce05bbdd6
            JA4one: t12i3009h2_1d37bd780c83_3c1a69c14dde

```
### How to fix?

After applying first patch, necessary applying secondary patch:
```bash
cd <source_of_nginx>
patch -p1 < ../ja4-nginx-module/patches/nginx.patch
patch -p1 < ../ja4-nginx-module/patches/wb-ja4-version-error.patch
make -j
```
### Result
```bash
curl -k --tls-max 1.2 https://127.0.0.1:8443/; echo
            JA4:    t12i2706h2_a2460661a67a_a44c6288192a
            JA4one: t12i2705h2_a2460661a67a_52333a2beb0b
            
curl -k --tls-max 1.3 https://127.0.0.1:8443/; echo
            JA4:    t13i3011h2_1d37bd780c83_b26ce05bbdd6
            JA4one: t13i3009h2_1d37bd780c83_3c1a69c14dde
            
```
