### PR TITLE
Introduce multi-stage builds for the container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!patches/
+!src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,9 @@ WORKDIR /tmp
 COPY --from=build-cache /tmp/nginx-${NGINX_VERSION} /tmp/nginx-${NGINX_VERSION}
 COPY --from=build-cache /tmp/openssl-${OPENSSL_VERSION} /tmp/openssl-${OPENSSL_VERSION}
 
-COPY . /tmp/ja4-nginx-module
 
 # Patch OpenSSL
+COPY ./patches/openssl.patch /tmp/ja4-nginx-module/patches/
 WORKDIR /tmp/openssl-${OPENSSL_VERSION}
 RUN patch -p1 < /tmp/ja4-nginx-module/patches/openssl.patch
 
@@ -68,6 +68,7 @@ RUN make -j$(nproc) && \
     make install_sw LIBDIR=lib
 
 # Patch nginx
+COPY . /tmp/ja4-nginx-module
 WORKDIR /tmp/nginx-${NGINX_VERSION}
 RUN patch -p1 < /tmp/ja4-nginx-module/patches/nginx.patch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine
+# -------- Stage 1: Common base with packages --------
+FROM alpine AS base
 
-# Define the version as a build argument for easy updates
-ARG NGINX_VERSION=1.24.0
-ARG OPENSSL_VERSION=3.2.1
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apk add --no-cache \
     gcc \
     libc-dev \
@@ -15,43 +15,73 @@ RUN apk add --no-cache \
     perl-dev \
     linux-headers
 
-
 RUN adduser -D dswebuser
+
+# -------- Stage 2: Precompiled sources for caching --------
+FROM base AS build-cache
+
+ARG NGINX_VERSION=1.24.0
+ARG OPENSSL_VERSION=3.2.1
 
 WORKDIR /tmp
 
-COPY . ./ja4-nginx-module
-
-# INSTALL NGINX
+# Download and extract
+# Nginx source code
 RUN wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxvf nginx-${NGINX_VERSION}.tar.gz
-
-# INSTALL OpenSSL
+# OpenSSL source code
 RUN wget https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz && \
     tar -zxvf openssl-${OPENSSL_VERSION}.tar.gz
 
-# patch openssl
-WORKDIR /tmp/openssl-${OPENSSL_VERSION}
+COPY src/config /tmp/ja4-nginx-module/src/config
+COPY src/ngx_http_ssl_ja4_module.c.dummy /tmp/ja4-nginx-module/src/ngx_http_ssl_ja4_module.c
 
+WORKDIR /tmp/nginx-${NGINX_VERSION}
+RUN ./configure \
+      --with-openssl=/tmp/openssl-${OPENSSL_VERSION} \
+      --with-debug --with-compat \
+      --add-module=/tmp/ja4-nginx-module/src \
+      --with-http_ssl_module \
+      --prefix=/etc/nginx && \
+    make -j$(nproc)
+
+# -------- Stage 3: Final build with actual module and patches --------
+FROM base AS final
+
+ARG NGINX_VERSION=1.24.0
+ARG OPENSSL_VERSION=3.2.1
+
+WORKDIR /tmp
+
+# Copy sources from build cache
+COPY --from=build-cache /tmp/nginx-${NGINX_VERSION} /tmp/nginx-${NGINX_VERSION}
+COPY --from=build-cache /tmp/openssl-${OPENSSL_VERSION} /tmp/openssl-${OPENSSL_VERSION}
+
+COPY . /tmp/ja4-nginx-module
+
+# Patch OpenSSL
+WORKDIR /tmp/openssl-${OPENSSL_VERSION}
 RUN patch -p1 < /tmp/ja4-nginx-module/patches/openssl.patch
 
-# patch nginx
-WORKDIR /tmp/nginx-${NGINX_VERSION}
+# Rebuild only what's changed in the OpenSSL patch
+RUN make -j$(nproc) && \
+    make install_sw LIBDIR=lib
 
+# Patch nginx
+WORKDIR /tmp/nginx-${NGINX_VERSION}
 RUN patch -p1 < /tmp/ja4-nginx-module/patches/nginx.patch
 
-# Build Nginx
-RUN ./configure --with-openssl=/tmp/openssl-${OPENSSL_VERSION} --with-debug --with-compat --add-module=/tmp/ja4-nginx-module/src --with-http_ssl_module --prefix=/etc/nginx && \
-    make && \
+# Rebuild only what's changed in the nginx patch or module
+RUN make -j$(nproc) && \
     make install
 
-# Cleanup
-WORKDIR /
-RUN rm -rf /tmp/
-
-# Link Nginx logs to stdout and stderr
+# Link logs
 RUN ln -sf /dev/stdout /etc/nginx/logs/access.log && \
     ln -sf /dev/stderr /etc/nginx/logs/error.log
 
-# CMD directive to run Nginx in the foreground
+# Clean up
+WORKDIR /
+RUN rm -rf /tmp/*
+
+# Run Nginx in the foreground
 CMD ["/etc/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ You can quickly test out this module with:
 1. `cd docker`
 2. `docker-compose up --build`
 
+A multi-stage `Dockerfile` is also included in the project root. You can run the build directly from the root using:
+
+```bash
+docker-compose up --build
+```
+
 You can also build from source with:
 
 1. `docker build -t ja4-nginx:source .`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  ja4-nginx:
+    container_name: ja4-nginx
+    build:
+      context: .
+      target: final
+    image: ja4-nginx:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: always
+    volumes:
+      - ./nginx_utils/nginx.conf:/etc/nginx/conf/nginx.conf
+      - ./nginx_utils/server.crt:/etc/nginx/conf/server.crt
+      - ./nginx_utils/server.key:/etc/nginx/conf/server.key
+      - ./nginx_utils/logs:/etc/nginx/logs

--- a/src/ngx_http_ssl_ja4_module.c.dummy
+++ b/src/ngx_http_ssl_ja4_module.c.dummy
@@ -1,0 +1,12 @@
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+ngx_module_t ngx_http_ssl_ja4_module = {
+    NGX_MODULE_V1,
+    NULL, /* module context */
+    NULL, /* module directives */
+    NGX_HTTP_MODULE, /* module type */
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NGX_MODULE_V1_PADDING
+};


### PR DESCRIPTION
Previously, the image was built entirely from scratch in a single stage, which resulted in very long build times, especially when iterating on small changes to the module.

### Benefits

* Rebuild time reduced from 250s to 16s
* If the OpenSSL patch changes, rebuild still completes in 60s
* Faster development iteration and improved layer caching