### PR TITLE
Fixed incorrect detection of the number of TLS ciphers.

### DIFF
--- a/patches/nginx.patch
+++ b/patches/nginx.patch
@@ -1,76 +1,74 @@
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index 104e8daf7..e0c46d21a 100644
+index a7b389444..6a21decab 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
-@@ -1759,6 +1759,212 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+@@ -1703,6 +1703,215 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+     return NGX_OK;
  }
- 
  
 +// adds ciphers to the ssl object for ja4 fingerprint
 +ngx_int_t
 +ngx_SSL_client_features(ngx_connection_t *c) {
 +
 +    SSL                           *s = NULL;
-+    size_t                        i,j;
-+    int                           index;
 +
 +    if (c == NULL) {
 +        return NGX_ERROR;
 +    }
 +    s = c->ssl->connection;
 +
-+    /* Cipher suites */
-+    c->ssl->ciphers = NULL;
-+    STACK_OF(SSL_CIPHER) *ciphers = SSL_get_client_ciphers(s);
++    uint8_t  *u_ciphers;
 +
-+    if (ciphers == NULL) {
-+        return NGX_ERROR; // Handle error
++    int tls_cipher_len = SSL_get0_raw_cipherlist (c->ssl->connection, NULL);
++    if (tls_cipher_len == 0) {
++        return NGX_ERROR;
 +    }
 +
-+    c->ssl->ciphers_sz = sk_SSL_CIPHER_num(ciphers);
-+
-+    if (c->ssl->ciphers_sz) {
-+        // Allocate memory for the array of cipher strings
-+        c->ssl->ciphers = ngx_pnalloc(c->pool, c->ssl->ciphers_sz * sizeof(char *));
-+        if (c->ssl->ciphers == NULL) {
-+            return NGX_ERROR; // Handle allocation failure
-+        }
-+
-+        // Convert each cipher suite to a hexadecimal string and store it
-+        for (i = 0; i < c->ssl->ciphers_sz; i++) {
-+            const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
-+            if (cipher == NULL) {
-+                return NGX_ERROR; // Handle error
-+            }
-+
-+            // Get the two-byte TLS cipher ID in network byte order
-+            unsigned char cipher_id_bytes[2];
-+            cipher_id_bytes[0] = (SSL_CIPHER_get_id(cipher) >> 8) & 0xFF;
-+            cipher_id_bytes[1] = SSL_CIPHER_get_id(cipher) & 0xFF;
-+
-+            const SSL_CIPHER *found_cipher = SSL_CIPHER_find(s, cipher_id_bytes);
-+            if (found_cipher == NULL) {
-+                return NGX_ERROR; // Handle error
-+            }
-+
-+            // Convert the cipher ID to a hexadecimal string
-+            char hex_str[6]; // Buffer to hold the hexadecimal string (4 digits + null terminator)
-+            snprintf(hex_str, sizeof(hex_str), "%02x%02x", cipher_id_bytes[0], cipher_id_bytes[1]);
-+
-+            // Allocate memory for the hex string and copy it
-+            c->ssl->ciphers[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
-+            if (c->ssl->ciphers[i] == NULL) {
-+                // Handle allocation failure and clean up previously allocated memory
-+                for (j = 0; j < i; j++) {
-+                    ngx_pfree(c->pool, c->ssl->ciphers[j]);
-+                }
-+                ngx_pfree(c->pool, c->ssl->ciphers);
-+                c->ssl->ciphers = NULL;
-+                return NGX_ERROR;
-+            }
-+            ngx_memcpy(c->ssl->ciphers[i], hex_str, sizeof(hex_str));
-+        }
++    int len = SSL_get0_raw_cipherlist (c->ssl->connection, &u_ciphers);
++    len /= tls_cipher_len;
++    if (len == 0) {
++        return NGX_ERROR;
 +    }
++
++    c->ssl->ciphers = ngx_pnalloc (c->pool, len * sizeof(char *));
++    if (c->ssl->ciphers == NULL) {
++        return NGX_ERROR;
++    }
++
++    c->ssl->ciphers_sz = 0;
++    for (int i = 0; i < len; i++) {
++        const SSL_CIPHER  *cipher = SSL_CIPHER_find(c->ssl->connection, u_ciphers + i * tls_cipher_len);
++
++        if (!cipher) {
++            continue; // Probably - GREASE value
++        }
++        uint16_t id = SSL_CIPHER_get_id (cipher) & 0xffff;
++        /*
++         * Convert the cipher ID to a hexadecimal string Buffer to
++         * hold the hexadecimal string (4 digits + null terminator)
++         **/
++        char hex_str[5];
++        snprintf (hex_str, sizeof(hex_str), "%04x", id);
++        /* Allocate memory for the hex string and copy it */
++        c->ssl->ciphers [c->ssl->ciphers_sz] = ngx_pnalloc(c->pool, sizeof(hex_str));
++        if (c->ssl->ciphers[c->ssl->ciphers_sz] == NULL) {
++            /* Handle allocation failure */
++            for (size_t j = 0; j < c->ssl->ciphers_sz; j++) {
++                ngx_pfree(c->pool, c->ssl->ciphers[j]);
++            }
++            ngx_pfree(c->pool, c->ssl->ciphers);
++            c->ssl->ciphers = NULL;
++            return NGX_ERROR;
++        }
++        ngx_memcpy (c->ssl->ciphers [c->ssl->ciphers_sz], hex_str, sizeof(hex_str));
++        c->ssl->ciphers_sz++;
++    }
++
++#if (NGX_DEBUG)
++    ngx_log_debug (NGX_LOG_DEBUG_EVENT, c->log, 0, "ja4: unsorted ciphers_suite:");
++    for (int i = 0; i < (int) c->ssl->ciphers_sz; i++)
++        ngx_log_debug2 (NGX_LOG_DEBUG_EVENT, c->log, 0, "-- [%2d]: %s", i, c->ssl->ciphers[i]);
++#endif
 +
 +    /* Signature Algorithms */
 +    int num_sigalgs = SSL_get_sigalgs(s, 0, NULL, NULL, NULL, NULL, NULL);
@@ -82,24 +80,30 @@ index 104e8daf7..e0c46d21a 100644
 +            return NGX_ERROR;
 +        }
 +
-+        for (index = 0; index < num_sigalgs; ++index) {
++        for (int i = 0; i < num_sigalgs; ++i) {
 +            int psign, phash, psignhash;
 +            unsigned char rsig, rhash;
-+            SSL_get_sigalgs(s, index, &psign, &phash, &psignhash, &rsig, &rhash);
++            SSL_get_sigalgs(s, i, &psign, &phash, &psignhash, &rsig, &rhash);
 +
 +            // Format as a hexadecimal string
 +            char hex_string[5]; // Enough for "XXXX" + null terminator
 +            snprintf(hex_string, sizeof(hex_string), "%02x%02x", rhash, rsig);
 +
 +            // Allocate memory for the hex string
-+            sigalgs_hex_strings[index] = ngx_pnalloc(c->pool, sizeof(hex_string));
-+            if (sigalgs_hex_strings[index] == NULL) {
++            sigalgs_hex_strings[i] = ngx_pnalloc(c->pool, sizeof(hex_string));
++            if (sigalgs_hex_strings[i] == NULL) {
++                // Handle allocation failure and clean up previously allocated memory
++                for (int j = 0; j < i; j++) {
++                    ngx_pfree(c->pool, sigalgs_hex_strings[j]);
++                }
++                ngx_pfree(c->pool, sigalgs_hex_strings);
++                sigalgs_hex_strings = NULL;
 +                ngx_log_error(NGX_LOG_ERR, c->log, 0, "Failed to allocate memory for a signature algorithm hex string");
 +                return NGX_ERROR;
 +            }
 +
 +            // Copy the hex string into allocated memory
-+            ngx_memcpy(sigalgs_hex_strings[index], hex_string, sizeof(hex_string));
++            ngx_memcpy(sigalgs_hex_strings[i], hex_string, sizeof(hex_string));
 +        }
 +
 +        // Save the array of hex strings to your struct
@@ -115,7 +119,7 @@ index 104e8daf7..e0c46d21a 100644
 +
 +    int                            got_extensions;
 +    int                           *ext_out;
-+    size_t                         ext_len, i, j;
++    size_t                         ext_len;
 +
 +    // Declare the highest client TLS protocol version
 +    int                            highest_supported_tls_client_version;
@@ -156,7 +160,7 @@ index 104e8daf7..e0c46d21a 100644
 +
 +    c->ssl->extensions = ngx_palloc(c->pool, sizeof(char *) * ext_len);
 +    if (c->ssl->extensions != NULL) {
-+        for (i = 0; i < ext_len; i++) {
++        for (size_t i = 0; i < ext_len; i++) {
 +            char hex_str[6];  // Buffer to hold the hexadecimal string (4 digits + null terminator)
 +            snprintf(hex_str, sizeof(hex_str), "%04x", ext_out[i]);
 +
@@ -191,7 +195,7 @@ index 104e8daf7..e0c46d21a 100644
 +            c->ssl->extensions[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
 +            if (c->ssl->extensions[i] == NULL) {
 +                // Handle allocation failure and clean up previously allocated memory
-+                for (j = 0; j < i; j++) {
++                for (size_t j = 0; j < i; j++) {
 +                    ngx_pfree(c->pool, c->ssl->extensions[j]);
 +                }
 +                ngx_pfree(c->pool, c->ssl->extensions);
@@ -203,7 +207,7 @@ index 104e8daf7..e0c46d21a 100644
 +        c->ssl->extensions_sz = ext_len;
 +    }
 +
-+    for (i = 0; i < ext_len; i++) {
++    for (size_t i = 0; i < ext_len; i++) {
 +        ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0, "c->ssl->extensions[%zu] = %s", i, c->ssl->extensions[i]);
 +    }
 +
@@ -211,11 +215,10 @@ index 104e8daf7..e0c46d21a 100644
 +
 +    return 1;
 +}
-+
+ 
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
- {
-@@ -1778,12 +1982,16 @@ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1723,12 +1932,16 @@ ngx_ssl_handshake(ngx_connection_t *c)
  
      ngx_ssl_clear_error(c->log);
  
@@ -235,10 +238,10 @@ index 104e8daf7..e0c46d21a 100644
              return NGX_ERROR;
          }
 diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index 860ea26dd..da58ed0ad 100644
+index 9e68deb44..9610be790 100644
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
-@@ -120,6 +120,25 @@ struct ngx_ssl_connection_s {
+@@ -146,6 +146,25 @@ struct ngx_ssl_connection_s {
      unsigned                    in_ocsp:1;
      unsigned                    early_preread:1;
      unsigned                    write_blocked:1;
@@ -265,11 +268,11 @@ index 860ea26dd..da58ed0ad 100644
  
  
 diff --git a/src/http/modules/ngx_http_ssl_module.c b/src/http/modules/ngx_http_ssl_module.c
-index 4c4a598b1..93b7c4f5f 100644
+index dbfe5c08b..80589a3a4 100644
 --- a/src/http/modules/ngx_http_ssl_module.c
 +++ b/src/http/modules/ngx_http_ssl_module.c
-@@ -431,6 +431,13 @@ ngx_http_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn, const unsigned char **out,
-     ngx_connection_t       *c;
+@@ -440,6 +440,13 @@ ngx_http_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn, const unsigned char **out,
+     ngx_connection_t        *c;
  
      c = ngx_ssl_get_connection(ssl_conn);
 +    // add first alpn value for ja4 to c->ssl


### PR DESCRIPTION
### Description
There is an error in determining the number of ciphers in the suit:
```bash
curl -k --tls-max 1.2 https://127.0.0.1:8443/; echo
```
gives
```bash
            JA4:    t13i2706h2_a2460661a67a_a44c6288192a
            JA4one: t13i2705h2_a2460661a67a_52333a2beb0b
```
but wireshark decode next parameter of `Client TLS Hello`

![Screenshot at 2025-06-27 13-57-09](https://github.com/user-attachments/assets/322c444b-1a79-491c-a40f-cb10a066ff99)

The same for tls 1.3.
```bash
curl -k --tls-max 1.3 https://127.0.0.1:8443/;  done; echo
```
Before this PR
```bash
JA4 :   t13i3011h2_1d37bd780c83_b26ce05bbdd6
```
after 
```bash
JA4 :   t13i3111h2_e8f1e7e78f70_b26ce05bbdd6
```

### How to applay?

```bash
cd <source_of_nginx>
git checkout .
patch -p1 < ../ja4-nginx-module/patches/nginx.patch
make -j
```