### PR TITLE
Fixed array out of bounds error

### DIFF
--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -171,6 +171,9 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
         for (i = 0; i < c->ssl->ciphers_sz; ++i)
         {
             size_t hex_str_len = strlen(c->ssl->ciphers[i]) + 1; // +1 for null terminator
+            if (ngx_ssl_ja4_is_ext_greased(c->ssl->ciphers[i])) {
+                continue;
+            }
 
             // Allocate memory for the hex string and copy it
             ja4->ciphers[ja4->ciphers_sz] = ngx_pnalloc(pool, hex_str_len);
@@ -384,6 +387,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
             sprintf(hex_hash + 2 * i, "%02x", hash_result[i]);
         }
         ngx_memcpy(ja4->extension_hash, hex_hash, 2 * SHA256_DIGEST_LENGTH);
+        ja4->extension_hash[2 * SHA256_DIGEST_LENGTH] = '\0';
 
         // Convert the truncated hash to hexadecimal format
         char hex_hash_truncated[2 * 6 + 1]; // 6 bytes, 2 characters each = 12 characters plus null-terminator
@@ -426,6 +430,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
             sprintf(hex_hash + 2 * i, "%02x", hash_result[i]);
         }
         ngx_memcpy(ja4->extension_hash_no_psk, hex_hash, 2 * SHA256_DIGEST_LENGTH);
+        ja4->extension_hash_no_psk[2 * SHA256_DIGEST_LENGTH] = '\0';
 
         // Convert the truncated hash to hexadecimal format
         char hex_hash_truncated[2 * 6 + 1]; // 6 bytes, 2 characters each = 12 characters plus null-terminator


### PR DESCRIPTION
Without this fix, there is a risk of array bounds violation when calculating some fields,\
such as `extension_hash_no_psk`

Without this fix:
```bash
...
2025/06/26 18:06:26 [debug] 4043860#0: *1 ssl_ja4: extension hash no psk: 52333a2beb0b0210d5d13d19d42ff1617cdd302bee4ba25878e6495e2c00ba5dt52333a2beb0b
...
```
has length 78 bytes.
```bash
wc <<< 52333a2beb0b0210d5d13d19d42ff1617cdd302bee4ba25878e6495e2c00ba5dt52333a2beb0b
      1       1      78
```

With this fix
```bash
...
2025/06/27 11:15:48 [debug] 4158422#0: *1 ssl_ja4: extension hash no psk: 52333a2beb0b0210d5d13d19d42ff1617cdd302bee4ba25878e6495e2c00ba5d
...
```
has length 65 bytes.
```bash
wc <<< 52333a2beb0b0210d5d13d19d42ff1617cdd302bee4ba25878e6495e2c00ba5d
      1       1      65
```