### PR TITLE
Fix: wrong detection TLS version

### DIFF
--- a/patches/nginx.patch
+++ b/patches/nginx.patch
@@ -1,8 +1,8 @@
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index a7b389444..6a21decab 100644
+index 0681ca3a2..9106127e9 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
-@@ -1703,6 +1703,215 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+@@ -1698,6 +1698,183 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
      return NGX_OK;
  }
  
@@ -121,15 +121,6 @@ index a7b389444..6a21decab 100644
 +    int                           *ext_out;
 +    size_t                         ext_len;
 +
-+    // Declare the highest client TLS protocol version
-+    int                            highest_supported_tls_client_version;
-+
-+    const unsigned char           *supported_versions_ext;
-+    size_t                         supported_versions_ext_len;
-+
-+    const unsigned char           *supported_versions;
-+    size_t                         supported_versions_len;
-+
 +    ngx_connection_t              *c;
 +
 +    c = arg;
@@ -164,31 +155,8 @@ index a7b389444..6a21decab 100644
 +            char hex_str[6];  // Buffer to hold the hexadecimal string (4 digits + null terminator)
 +            snprintf(hex_str, sizeof(hex_str), "%04x", ext_out[i]);
 +
-+            // Check for the supported_versions extension (0x002b) in the ClientHello
-+            if (ext_out[i] == 0x002b) {
-+                ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "Found supported_versions extension (0x002b)");
-+
-+                if (SSL_client_hello_get0_ext(s, 0x002b, &supported_versions_ext, &supported_versions_ext_len)) {
-+
-+                    // Skip the first byte as it denotes the length of the list
-+                    supported_versions_len = supported_versions_ext_len - 1;
-+
-+                    supported_versions = supported_versions_ext + 1;
-+                    highest_supported_tls_client_version = 0;
-+
-+                    // Extracts and constructs SSL/TLS versions from supported_versions array
-+                    for (size_t j = 0; j + 1 < supported_versions_len; j += 2) {
-+                        int version = (supported_versions[j] << 8) | supported_versions[j + 1];
-+
-+                        if (version > highest_supported_tls_client_version) {
-+                            highest_supported_tls_client_version = version;
-+                        }
-+                    }
-+
-+                    // Set highest supported TLS version for JA4 module
-+                    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "Highest TLS protocol version found: %d", highest_supported_tls_client_version);
-+                    c->ssl->highest_supported_tls_client_version = highest_supported_tls_client_version;
-+                }
++            if (ext_out[i] == TLSEXT_TYPE_supported_versions) {
++                c->ssl->version = TLS1_3_VERSION;
 +            }
 +
 +            // Allocate memory for the hex string and copy it
@@ -218,7 +186,7 @@ index a7b389444..6a21decab 100644
  
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
-@@ -1723,12 +1932,16 @@ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1718,12 +1895,16 @@ ngx_ssl_handshake(ngx_connection_t *c)
  
      ngx_ssl_clear_error(c->log);
  
@@ -238,10 +206,10 @@ index a7b389444..6a21decab 100644
              return NGX_ERROR;
          }
 diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index 9e68deb44..9610be790 100644
+index 9ad4d177b..9e46ed51f 100644
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
-@@ -146,6 +146,25 @@ struct ngx_ssl_connection_s {
+@@ -133,6 +133,25 @@ struct ngx_ssl_connection_s {
      unsigned                    in_ocsp:1;
      unsigned                    early_preread:1;
      unsigned                    write_blocked:1;

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -115,10 +115,10 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
     /* SSLVersion*/
     // get string version:
     int client_version_int = SSL_client_version(ssl);
-    int max_version_int = c->ssl->highest_supported_tls_client_version;
+    int max_version_int = SSL_get_max_proto_version(ssl);
     int version_int = 0;
 
-    if (max_version_int) {
+    if (c->ssl->version) {
         version_int = max_version_int;
     } else {
         version_int = client_version_int;

--- a/src/ngx_http_ssl_ja4_module.h
+++ b/src/ngx_http_ssl_ja4_module.h
@@ -285,7 +285,7 @@ ngx_ssl_ja4_detail_print(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
 
     /* Version */
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT,
-                   pool->log, 0, "ssl_ja4: Version:  %d\n", ja4->version);
+                   pool->log, 0, "ssl_ja4: Version:  %s\n", ja4->version);
 
     /* Ciphers */
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT,
@@ -379,7 +379,7 @@ ngx_ssl_ja4_detail_print(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
     //                    ja4->alpn_first_value);
     // }
 }
-    
+
 #endif
 
 // FUNCTION PROTOTYPES


### PR DESCRIPTION
## Description

Currently ja4 from HEAD ([3b22f32](https://github.com/FoxIO-LLC/ja4-nginx-module/commit/3b22f3257fe4cc048134b96a8f829a7d8c029c40)) gives an error calculation the `tls version`.<br>For example for Chrome:
```code
JA4 : t00d1516h2_8daaf6152771_d8a2da3f94cd
```
This `PR` fixes this bug.
```code
JA4 : t13d1516h2_8daaf6152771_d8a2da3f94cd
```