### PR TITLE
ja4 variables caching

### DIFF
--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -1818,6 +1818,12 @@ ngx_http_ssl_ja4_init_ctx(ngx_http_request_t *r, ngx_http_ssl_ja4_ctx_t **ctx_ou
 {
     ngx_http_ssl_ja4_ctx_t *ctx;
     ctx = ngx_http_get_module_ctx(r, ngx_http_ssl_ja4_module);
+
+    if (ctx != NULL && ctx_out) {
+        *ctx_out = ctx;
+        return NGX_OK;
+    }
+
     ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_ssl_ja4_ctx_t));
     if (ctx == NULL) {
         return NGX_ERROR;

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -537,8 +537,8 @@ static ngx_int_t
 ngx_http_ssl_ja4(ngx_http_request_t *r,
                  ngx_http_variable_value_t *v, uintptr_t data)
 {
+    ngx_http_ssl_ja4_ctx_t *ctx;
     ngx_ssl_ja4_t ja4;
-    ngx_str_t fp = ngx_null_string;
 
     if (r->connection == NULL)
     {
@@ -549,10 +549,24 @@ ngx_http_ssl_ja4(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    ngx_ssl_ja4_fp(r->pool, &ja4, &fp);
+    ctx = ngx_http_get_module_ctx(r, ngx_http_ssl_ja4_module);
+    if (ctx == NULL) {
+        ngx_int_t res = ngx_http_ssl_ja4_init_ctx(r, &ctx);
+        if (res != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
 
-    v->data = fp.data;
-    v->len = fp.len;
+    if (ctx->ja4.len == 0) {
+        ngx_str_t fp = ngx_null_string;
+        ngx_ssl_ja4_fp(r->pool, &ja4, &fp);
+        ctx->ja4.len = fp.len;
+        ctx->ja4.data = ngx_pnalloc(r->pool, fp.len);
+        ngx_memcpy(ctx->ja4.data, fp.data, fp.len);
+    }
+
+    v->data = ctx->ja4.data;
+    v->len = ctx->ja4.len;
     v->valid = 1;
     v->no_cacheable = 1;
     v->not_found = 0;
@@ -711,8 +725,8 @@ static ngx_int_t
 ngx_http_ssl_ja4_string(ngx_http_request_t *r,
                         ngx_http_variable_value_t *v, uintptr_t data)
 {
+    ngx_http_ssl_ja4_ctx_t *ctx;
     ngx_ssl_ja4_t ja4;
-    ngx_str_t fp = ngx_null_string;
 
     if (r->connection == NULL)
     {
@@ -724,10 +738,24 @@ ngx_http_ssl_ja4_string(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    ngx_ssl_ja4_fp_string(r->pool, &ja4, &fp);
+    ctx = ngx_http_get_module_ctx(r, ngx_http_ssl_ja4_module);
+    if (ctx == NULL) {
+        ngx_int_t res = ngx_http_ssl_ja4_init_ctx(r, &ctx);
+        if (res != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
 
-    v->data = fp.data;
-    v->len = fp.len;
+    if (ctx->ja4_string.len == 0) {
+        ngx_str_t fp = ngx_null_string;
+        ngx_ssl_ja4_fp_string(r->pool, &ja4, &fp);
+        ctx->ja4_string.len = fp.len;
+        ctx->ja4_string.data = ngx_pnalloc(r->pool, fp.len);
+        ngx_memcpy(ctx->ja4_string.data, fp.data, fp.len);
+    }
+
+    v->data = ctx->ja4_string.data;
+    v->len = ctx->ja4_string.len;
     v->valid = 1;
     v->no_cacheable = 1;
     v->not_found = 0;
@@ -827,8 +855,8 @@ static ngx_int_t
 ngx_http_ssl_ja4one(ngx_http_request_t *r,
                     ngx_http_variable_value_t *v, uintptr_t data)
 {
+    ngx_http_ssl_ja4_ctx_t *ctx;
     ngx_ssl_ja4_t ja4;
-    ngx_str_t fp = ngx_null_string;
 
     if (r->connection == NULL)
     {
@@ -839,10 +867,24 @@ ngx_http_ssl_ja4one(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    ngx_ssl_ja4one_fp(r->pool, &ja4, &fp);
+    ctx = ngx_http_get_module_ctx(r, ngx_http_ssl_ja4_module);
+    if (ctx == NULL) {
+        ngx_int_t res = ngx_http_ssl_ja4_init_ctx(r, &ctx);
+        if (res != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
 
-    v->data = fp.data;
-    v->len = fp.len;
+    if (ctx->ja4one.len == 0) {
+        ngx_str_t fp = ngx_null_string;
+        ngx_ssl_ja4one_fp(r->pool, &ja4, &fp);
+        ctx->ja4one.len = fp.len;
+        ctx->ja4one.data = ngx_pnalloc(r->pool, fp.len);
+        ngx_memcpy(ctx->ja4one.data, fp.data, fp.len);
+    }
+
+    v->data = ctx->ja4one.data;
+    v->len = ctx->ja4one.len;
     v->valid = 1;
     v->no_cacheable = 1;
     v->not_found = 0;
@@ -1770,3 +1812,24 @@ ngx_module_t ngx_http_ssl_ja4_module = {
     NULL,                         /* exit process */
     NULL,                         /* exit master */
     NGX_MODULE_V1_PADDING};
+
+static ngx_int_t
+ngx_http_ssl_ja4_init_ctx(ngx_http_request_t *r, ngx_http_ssl_ja4_ctx_t **ctx_out)
+{
+    ngx_http_ssl_ja4_ctx_t *ctx;
+    ctx = ngx_http_get_module_ctx(r, ngx_http_ssl_ja4_module);
+    ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_ssl_ja4_ctx_t));
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+    ngx_http_set_ctx(r, ctx, ngx_http_ssl_ja4_module);
+    ctx->ja4 = (ngx_str_t){0, NULL};
+    ctx->ja4_string = (ngx_str_t){0, NULL};
+    ctx->ja4one = (ngx_str_t){0, NULL};
+
+    ngx_http_set_ctx(r, ctx, ngx_http_ssl_ja4_module);
+    if (ctx_out)
+        *ctx_out = ctx;
+
+    return NGX_OK;
+}

--- a/src/ngx_http_ssl_ja4_module.h
+++ b/src/ngx_http_ssl_ja4_module.h
@@ -393,7 +393,7 @@ ngx_module_t ngx_http_ssl_ja4_module;
 // INIT
 static ngx_int_t ngx_http_ssl_ja4_init(ngx_conf_t *cf);
 
-static ngx_int_t ngx_http_ssl_ja4_init_ctx(ngx_http_request_t *r, ngx_http_ssl_ja4_ctx_t **ctx_out);
+static ngx_http_ssl_ja4_ctx_t *ngx_get_or_create_ja4_ctx(ngx_http_request_t *r);
 
 // JA4
 int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4);

--- a/src/ngx_http_ssl_ja4_module.h
+++ b/src/ngx_http_ssl_ja4_module.h
@@ -2,6 +2,12 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 
+typedef struct {
+    ngx_str_t   ja4;
+    ngx_str_t   ja4_string;
+    ngx_str_t   ja4one;
+} ngx_http_ssl_ja4_ctx_t;
+
 // STRUCTS
 typedef struct ngx_ssl_ja4_s
 {
@@ -379,12 +385,15 @@ ngx_ssl_ja4_detail_print(ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
     //                    ja4->alpn_first_value);
     // }
 }
-    
 #endif
+
+ngx_module_t ngx_http_ssl_ja4_module;
 
 // FUNCTION PROTOTYPES
 // INIT
 static ngx_int_t ngx_http_ssl_ja4_init(ngx_conf_t *cf);
+
+static ngx_int_t ngx_http_ssl_ja4_init_ctx(ngx_http_request_t *r, ngx_http_ssl_ja4_ctx_t **ctx_out);
 
 // JA4
 int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4);


### PR DESCRIPTION
#### This `PR` introduced ja4 variable caching.

If a ja4 variable is used multiple times during request processing, it is evaluated only the first time and then its value is used.