### PR TITLE
Improve TLS client version detection in ClientHello

### DIFF
--- a/patches/nginx.patch
+++ b/patches/nginx.patch
@@ -2,7 +2,7 @@ diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
 index a7b389444..6a21decab 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
-@@ -1703,6 +1703,215 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+@@ -1703,6 +1703,222 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
      return NGX_OK;
  }
  
@@ -128,7 +128,6 @@ index a7b389444..6a21decab 100644
 +    size_t                         supported_versions_ext_len;
 +
 +    const unsigned char           *supported_versions;
-+    size_t                         supported_versions_len;
 +
 +    ngx_connection_t              *c;
 +
@@ -169,25 +168,33 @@ index a7b389444..6a21decab 100644
 +                ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "Found supported_versions extension (0x002b)");
 +
 +                if (SSL_client_hello_get0_ext(s, 0x002b, &supported_versions_ext, &supported_versions_ext_len)) {
-+
-+                    // Skip the first byte as it denotes the length of the list
-+                    supported_versions_len = supported_versions_ext_len - 1;
-+
-+                    supported_versions = supported_versions_ext + 1;
-+                    highest_supported_tls_client_version = 0;
-+
-+                    // Extracts and constructs SSL/TLS versions from supported_versions array
-+                    for (size_t j = 0; j + 1 < supported_versions_len; j += 2) {
-+                        int version = (supported_versions[j] << 8) | supported_versions[j + 1];
-+
-+                        if (version > highest_supported_tls_client_version) {
-+                            highest_supported_tls_client_version = version;
++                    if (supported_versions_ext_len < 3) {
++                        ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "supported_versions extension too short");
++                        highest_supported_tls_client_version = SSL_client_hello_get0_legacy_version(s);
++                    } else {
++                        size_t list_len = supported_versions_ext[0];
++                        if (list_len + 1 > supported_versions_ext_len) {
++                            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "supported_versions length mismatch");
++                            highest_supported_tls_client_version = SSL_client_hello_get0_legacy_version(s);
++                        } else {
++                            supported_versions = supported_versions_ext + 1;
++                            highest_supported_tls_client_version = 0;
++                            for (size_t j = 0; j + 1 < list_len; j += 2) {
++                                int version = (supported_versions[j] << 8) | supported_versions[j + 1];
++                                // skip GREASE values (RFC 8701)
++                                if ((version & 0x0f0f) == 0x0a0a) continue;
++                                if (version > highest_supported_tls_client_version) {
++                                    highest_supported_tls_client_version = version;
++                                }
++                            }
++                            // fallback if all were GREASE
++                            if (highest_supported_tls_client_version == 0) {
++                                highest_supported_tls_client_version = SSL_client_hello_get0_legacy_version(s);
++                            }
 +                        }
 +                    }
-+
-+                    // Set highest supported TLS version for JA4 module
-+                    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "Highest TLS protocol version found: %d", highest_supported_tls_client_version);
 +                    c->ssl->highest_supported_tls_client_version = highest_supported_tls_client_version;
++                    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "Highest TLS protocol version found: %04x", highest_supported_tls_client_version);
 +                }
 +            }
 +


### PR DESCRIPTION
This change enhances parsing of the `supported_versions` (0x002b) TLS extension in the ClientHello to determine the client’s highest supported TLS version more accurately and safely.

Key improvements:

* Added bounds checking for extension length to prevent malformed input from being misparsed.
* Validated `list_len` field against actual extension size to detect mismatches.
* Implemented GREASE value filtering (RFC 8701) to ignore placeholder version numbers.
* Added fallback to `SSL_client_hello_get0_legacy_version()` when extension is invalid, empty, or contains only GREASE.
* Changed log output to display the detected version in hexadecimal format.
* Removed unused `supported_versions_len` variable.

This makes TLS version detection more robust, avoids logging misleading GREASE versions, and improves diagnostic output.