### PR TITLE
Fixes for memory issues causing crashes

### DIFF
--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -179,7 +179,8 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
             return NGX_ERROR;
         }
 
-        ngx_memcpy(ja4->ciphers[*k], &hex, sizeof (hex));
+        /* hex is 4 chars + NUL; copy only the used portion */
+        ngx_memcpy(ja4->ciphers[*k], hex, 5);
         (void)(*k)++;
     }
 
@@ -287,7 +288,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
 
     /* Signature Algorithms */
 
-    int num_sigalgs = SSL_get_sigalgs (ssl, -1, NULL, NULL, NULL, NULL, NULL);
+    int num_sigalgs = SSL_get_sigalgs (ssl, 0, NULL, NULL, NULL, NULL, NULL);
 
     if (num_sigalgs > -1) {
 
@@ -297,7 +298,7 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
             return NGX_ERROR;
         }
 
-        for (int i = -1; i < num_sigalgs; ++i) {
+        for (int i = 0; i < num_sigalgs; ++i) {
 
             int psign, phash, psignhash;
             unsigned char rsig, rhash;


### PR DESCRIPTION
- fix: bound cipher memcpy to 5 bytes (4 hex + NUL) to stop overflowing 5-byte pool alloc in ja4->ciphers copy
- Previously copied the entire hex stack buffer (longer than dest), corrupting request pools and crashing workers. ----
- fix: correct sigalgs iteration bounds in JA4
- Call SSL_get_sigalgs starting at index 0 (not -1) and loop i=0..num_sigalgs-1; avoids out-of-bounds write into the sigalgs array.

- These fixes are for items that were causing worker crashes with rapid requests. This was tested originally with 200 rapid tests which caused multiple crashes, after these patches it was tested again with 2,000 requests with no crashes.
- Verified this locally with no issues after these patches.