### PR TITLE
Fix Missing ECH (0xfe0d) and ALPS (0x44cd) extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN adduser -D dswebuser
 # -------- Stage 2: Precompiled sources for caching --------
 FROM base AS build-cache
 
-ARG NGINX_VERSION=1.25.0
-ARG OPENSSL_VERSION=3.2.1
+ARG NGINX_VERSION=1.28.1
+ARG OPENSSL_VERSION=3.5.4
 
 WORKDIR /tmp
 
@@ -52,8 +52,8 @@ RUN ./configure \
 # -------- Stage 3: Final build with actual module and patches --------
 FROM base AS final
 
-ARG NGINX_VERSION=1.25.0
-ARG OPENSSL_VERSION=3.2.1
+ARG NGINX_VERSION=1.28.1
+ARG OPENSSL_VERSION=3.5.4
 
 WORKDIR /tmp
 

--- a/patches/nginx.patch
+++ b/patches/nginx.patch
@@ -1,28 +1,292 @@
 diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index 58f052cab..05514c5b3 100644
+index defffa583..7258d8a39 100644
 --- a/src/event/ngx_event_openssl.c
 +++ b/src/event/ngx_event_openssl.c
-@@ -1837,6 +1837,114 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+@@ -1701,6 +1701,20 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
+ 
+     c->ssl = sc;
+ 
++    // Initialize JA4 extension parsing state
++    sc->extensions_sz = 0;
++    sc->extensions = NULL;
++    sc->client_hello_parsed = 0;
++    sc->raw_client_hello = NULL;
++    sc->raw_client_hello_len = 0;
++
++    // Set up message callback to capture raw ClientHello
++    // This must be done before the handshake starts
++    if (!(flags & NGX_SSL_CLIENT)) {
++        SSL_set_msg_callback(sc->connection, ngx_ssl_msg_callback);
++        SSL_set_msg_callback_arg(sc->connection, c);
++    }
++
      return NGX_OK;
  }
  
+@@ -1743,6 +1757,282 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+     return NGX_OK;
+ }
+ 
++// Message callback to capture raw ClientHello
++void
++ngx_ssl_msg_callback(int write_p, int version, int content_type,
++    const void *buf, size_t len, SSL *ssl, void *arg)
++{
++    ngx_connection_t  *c;
++    const u_char      *p;
++
++    c = arg;
++
++    if (c == NULL || c->ssl == NULL) {
++        return;
++    }
++
++    ngx_log_debug4(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                   "ngx_ssl_msg_callback: write_p=%d, content_type=%d, len=%uz, parsed=%d",
++                   write_p, content_type, len, c->ssl->client_hello_parsed);
++
++    // Only process incoming handshake messages
++    if (write_p != 0 || content_type != 22) {  // 22 = handshake
++        return;
++    }
++
++    // Skip if already parsed
++    if (c->ssl->client_hello_parsed) {
++        return;
++    }
++
++    p = buf;
++
++    // Check if this is a ClientHello (type 1)
++    if (len < 1 || p[0] != 1) {
++        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                       "ngx_ssl_msg_callback: not ClientHello, type=%d",
++                       len > 0 ? (int)p[0] : -1);
++        return;
++    }
++
++    // Store the raw ClientHello data
++    c->ssl->raw_client_hello = ngx_pnalloc(c->pool, len);
++    if (c->ssl->raw_client_hello == NULL) {
++        return;
++    }
++
++    ngx_memcpy(c->ssl->raw_client_hello, buf, len);
++    c->ssl->raw_client_hello_len = len;
++    c->ssl->client_hello_parsed = 1;
++
++    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                   "Captured raw ClientHello: %uz bytes", len);
++}
++
++// Parse extensions from raw ClientHello data
++ngx_int_t
++ngx_ssl_parse_client_hello_extensions(ngx_connection_t *c)
++{
++    const u_char  *p, *end, *exts, *ext_end;
++    size_t         msg_len, sess_id_len, cipher_suites_len, comp_len;
++    size_t         exts_len, ext_type, ext_len;
++    ngx_array_t   *extensions;
++    unsigned int  *ext_ptr;
++    size_t         i;
++    char           hex_str[6];
++
++    if (c->ssl->raw_client_hello == NULL || c->ssl->raw_client_hello_len == 0) {
++        return NGX_ERROR;
++    }
++
++    p = c->ssl->raw_client_hello;
++    end = p + c->ssl->raw_client_hello_len;
++
++    // Skip handshake type (1 byte)
++    p++;
++
++    if (end - p < 3) {
++        return NGX_ERROR;
++    }
++
++    // Get message length (3 bytes)
++    msg_len = (p[0] << 16) | (p[1] << 8) | p[2];
++    p += 3;
++
++    if (end - p < (ngx_int_t)msg_len) {
++        return NGX_ERROR;
++    }
++
++    // Skip client version (2 bytes)
++    if (end - p < 2) {
++        return NGX_ERROR;
++    }
++    p += 2;
++
++    // Skip random (32 bytes)
++    if (end - p < 32) {
++        return NGX_ERROR;
++    }
++    p += 32;
++
++    // Get session ID length (1 byte)
++    if (end - p < 1) {
++        return NGX_ERROR;
++    }
++    sess_id_len = *p++;
++
++    // Skip session ID
++    if (end - p < (ssize_t)sess_id_len) {
++        return NGX_ERROR;
++    }
++    p += sess_id_len;
++
++    // Get cipher suites length (2 bytes)
++    if (end - p < 2) {
++        return NGX_ERROR;
++    }
++    cipher_suites_len = (p[0] << 8) | p[1];
++    p += 2;
++
++    // Parse cipher suites to detect SCSV values
++    if (end - p < (ssize_t)cipher_suites_len) {
++        return NGX_ERROR;
++    }
++
++    const u_char *cs_p = p;
++    const u_char *cs_end = p + cipher_suites_len;
++
++    while (cs_p + 1 < cs_end) {
++        unsigned int cipher = (cs_p[0] << 8) | cs_p[1];
++
++        // Check for TLS_EMPTY_RENEGOTIATION_INFO_SCSV (0x00ff)
++        if (cipher == 0x00ff) {
++            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                          "Detected TLS_EMPTY_RENEGOTIATION_INFO_SCSV (0x00ff)");
++        }
++
++        cs_p += 2;
++    }
++
++    p += cipher_suites_len;
++
++    // Get compression methods length (1 byte)
++    if (end - p < 1) {
++        return NGX_ERROR;
++    }
++    comp_len = *p++;
++
++    // Skip compression methods
++    if (end - p < (ssize_t)comp_len) {
++        return NGX_ERROR;
++    }
++    p += comp_len;
++
++    // Check if extensions are present
++    if (end - p < 2) {
++        // No extensions
++        return NGX_OK;
++    }
++
++    // Get extensions length (2 bytes)
++    exts_len = (p[0] << 8) | p[1];
++    p += 2;
++
++    if (end - p < (ssize_t)exts_len) {
++        return NGX_ERROR;
++    }
++
++    exts = p;
++    ext_end = p + exts_len;
++
++    // Create a temporary array to store all extension types
++    extensions = ngx_array_create(c->pool, 32, sizeof(unsigned int));
++    if (extensions == NULL) {
++        return NGX_ERROR;
++    }
++
++    // Parse all extensions
++    p = exts;
++    while (p + 3 < ext_end) {
++        ext_type = (p[0] << 8) | p[1];
++        ext_len = (p[2] << 8) | p[3];
++        p += 4;
++
++        if (ext_end - p < (ngx_int_t)ext_len) {
++            return NGX_ERROR;
++        }
++
++        // Add extension type to array
++        ext_ptr = ngx_array_push(extensions);
++        if (ext_ptr == NULL) {
++            return NGX_ERROR;
++        }
++        *ext_ptr = ext_type;
++
++        ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                      "Found extension: 0x%04xi (length: %uz)", ext_type, ext_len);
++
++        // Check for supported_versions extension (0x002b)
++        if (ext_type == 0x002b && ext_len >= 3) {
++            const u_char *sv = p;
++            size_t list_len = sv[0];
++
++            if (list_len + 1 <= ext_len) {
++                const u_char *versions = sv + 1;
++                int highest = 0;
++
++                for (size_t j = 0; j + 1 < list_len; j += 2) {
++                    int ver = (versions[j] << 8) | versions[j + 1];
++
++                    // Skip GREASE values (RFC 8701)
++                    if ((ver & 0x0f0f) == 0x0a0a) {
++                        continue;
++                    }
++
++                    if (ver > highest) {
++                        highest = ver;
++                    }
++                }
++
++                if (highest != 0) {
++                    c->ssl->highest_supported_tls_client_version = highest;
++                    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                                  "Highest TLS version from supported_versions: 0x%04xd",
++                                  highest);
++                }
++            }
++        }
++
++        p += ext_len;
++    }
++
++    // Convert extensions array to hex strings
++    c->ssl->extensions_sz = extensions->nelts;
++    c->ssl->extensions = ngx_palloc(c->pool, sizeof(char *) * extensions->nelts);
++
++    if (c->ssl->extensions == NULL) {
++        return NGX_ERROR;
++    }
++
++    ext_ptr = extensions->elts;
++    for (i = 0; i < extensions->nelts; i++) {
++        snprintf(hex_str, sizeof(hex_str), "%04x", ext_ptr[i]);
++
++        c->ssl->extensions[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
++        if (c->ssl->extensions[i] == NULL) {
++            return NGX_ERROR;
++        }
++
++        ngx_memcpy(c->ssl->extensions[i], hex_str, sizeof(hex_str));
++
++        ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                      "c->ssl->extensions[%uz] = %s", i, c->ssl->extensions[i]);
++    }
++
++    return NGX_OK;
++}
++
 +// adds extensions to the ssl object for ja4 fingerprint
 +int
 +ngx_SSL_early_cb_fn(SSL *s, int *al, void *arg) {
 +
-+    int                            got_extensions;
-+    int                           *ext_out;
-+    size_t                         ext_len;
-+
-+    // Declare the highest client TLS protocol version
-+    int                            highest_supported_tls_client_version;
-+
-+    const unsigned char           *supported_versions_ext;
-+    size_t                         supported_versions_ext_len;
-+
-+    const unsigned char           *supported_versions;
-+
-+    ngx_connection_t              *c;
++    ngx_connection_t  *c;
 +
 +    c = arg;
 +
@@ -34,90 +298,15 @@ index 58f052cab..05514c5b3 100644
 +        return 1;
 +    }
 +
-+    c->ssl->extensions_sz = 0;
-+    c->ssl->extensions = NULL;
-+    got_extensions = SSL_client_hello_get1_extensions_present (s, &ext_out, &ext_len);
-+
-+    if (!got_extensions) {
-+        return 1;
-+    }
-+    if (!ext_out) {
-+        return 1;
-+    }
-+    if (!ext_len) {
-+        return 1;
-+    }
-+
-+    c->ssl->extensions = ngx_palloc(c->pool, sizeof(char *) * ext_len);
-+    if (c->ssl->extensions != NULL) {
-+        for (size_t i = 0; i < ext_len; i++) {
-+            char hex_str[6];  // Buffer to hold the hexadecimal string (4 digits + null terminator)
-+            snprintf(hex_str, sizeof(hex_str), "%04x", ext_out[i]);
-+
-+            // Check for the supported_versions extension (0x002b) in the ClientHello
-+            if (ext_out[i] == 0x002b) {
-+                ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "Found supported_versions extension (0x002b)");
-+
-+                if (SSL_client_hello_get0_ext(s, 0x002b, &supported_versions_ext, &supported_versions_ext_len)) {
-+                    if (supported_versions_ext_len < 3) {
-+                        ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "supported_versions extension too short");
-+                        highest_supported_tls_client_version = SSL_client_hello_get0_legacy_version(s);
-+                    } else {
-+                        size_t list_len = supported_versions_ext[0];
-+                        if (list_len + 1 > supported_versions_ext_len) {
-+                            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "supported_versions length mismatch");
-+                            highest_supported_tls_client_version = SSL_client_hello_get0_legacy_version(s);
-+                        } else {
-+                            supported_versions = supported_versions_ext + 1;
-+                            highest_supported_tls_client_version = 0;
-+                            for (size_t j = 0; j + 1 < list_len; j += 2) {
-+                                int version = (supported_versions[j] << 8) | supported_versions[j + 1];
-+                                // skip GREASE values (RFC 8701)
-+                                if ((version & 0x0f0f) == 0x0a0a) continue;
-+                                if (version > highest_supported_tls_client_version) {
-+                                    highest_supported_tls_client_version = version;
-+                                }
-+                            }
-+                            // fallback if all were GREASE
-+                            if (highest_supported_tls_client_version == 0) {
-+                                highest_supported_tls_client_version = SSL_client_hello_get0_legacy_version(s);
-+                            }
-+                        }
-+                    }
-+                    c->ssl->highest_supported_tls_client_version = highest_supported_tls_client_version;
-+                    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
-+                            "Highest TLS protocol version found: %04xd", highest_supported_tls_client_version);
-+                }
-+            }
-+
-+            // Allocate memory for the hex string and copy it
-+            c->ssl->extensions[i] = ngx_pnalloc(c->pool, sizeof(hex_str));
-+            if (c->ssl->extensions[i] == NULL) {
-+                // Handle allocation failure and clean up previously allocated memory
-+                for (size_t j = 0; j < i; j++) {
-+                    ngx_pfree(c->pool, c->ssl->extensions[j]);
-+                }
-+                ngx_pfree(c->pool, c->ssl->extensions);
-+                c->ssl->extensions = NULL;
-+                return 1;
-+            }
-+            ngx_memcpy(c->ssl->extensions[i], hex_str, sizeof(hex_str));
-+        }
-+        c->ssl->extensions_sz = ext_len;
-+    }
-+
-+    for (size_t i = 0; i < ext_len; i++) {
-+        ngx_log_debug2 (NGX_LOG_DEBUG_EVENT, c->log, 0, "c->ssl->extensions[%2d] = %s", i, c->ssl->extensions[i]);
-+    }
-+
-+    OPENSSL_free(ext_out);
++    // Message callback is already set up in ngx_ssl_create_connection()
++    // This callback just needs to return success
 +
 +    return 1;
 +}
  
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
-@@ -1857,6 +1965,9 @@ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1763,6 +2053,9 @@ ngx_ssl_handshake(ngx_connection_t *c)
  
      ngx_ssl_clear_error(c->log);
  
@@ -127,11 +316,35 @@ index 58f052cab..05514c5b3 100644
      n = SSL_do_handshake(c->ssl->connection);
  
      ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
+@@ -1823,6 +2116,11 @@ ngx_ssl_handshake(ngx_connection_t *c)
+             return NGX_AGAIN;
+         }
+ 
++        // Parse raw ClientHello to get all extensions including ECH and ALPS
++        if (c->ssl->client_hello_parsed && c->ssl->extensions_sz == 0) {
++            ngx_ssl_parse_client_hello_extensions(c);
++        }
++
+         c->ssl->handshaked = 1;
+ 
+         return NGX_OK;
+@@ -1968,6 +2266,11 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+             return NGX_AGAIN;
+         }
+ 
++        // Parse raw ClientHello to get all extensions including ECH and ALPS
++        if (c->ssl->client_hello_parsed && c->ssl->extensions_sz == 0) {
++            ngx_ssl_parse_client_hello_extensions(c);
++        }
++
+         c->ssl->handshaked = 1;
+ 
+         return NGX_OK;
 diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index 4c829933c..4c90486d1 100644
+index fe5107fb6..4ce964c2e 100644
 --- a/src/event/ngx_event_openssl.h
 +++ b/src/event/ngx_event_openssl.h
-@@ -145,6 +145,25 @@ struct ngx_ssl_connection_s {
+@@ -151,6 +151,30 @@ struct ngx_ssl_connection_s {
      unsigned                    in_ocsp:1;
      unsigned                    early_preread:1;
      unsigned                    write_blocked:1;
@@ -150,6 +363,11 @@ index 4c829933c..4c90486d1 100644
 +    char   **sigalgs_hash_values; // Array to store combined hash values like 0x0601
 +    char *first_alpn; // first ALPN protocol provided by the client
 +
++    // Raw ClientHello parsing
++    unsigned        client_hello_parsed:1;
++    u_char         *raw_client_hello;
++    size_t          raw_client_hello_len;
++
 +
 +    // ja4l
 +    uint16_t handshake_roundtrip_microseconds; // a whole number - max is probably thousands
@@ -157,20 +375,98 @@ index 4c829933c..4c90486d1 100644
  };
  
  
-@@ -378,4 +397,6 @@ extern int  ngx_ssl_index;
- extern int  ngx_ssl_certificate_name_index;
+@@ -383,4 +407,9 @@ extern int  ngx_ssl_certificate_name_index;
+ extern u_char  ngx_ssl_session_buffer[NGX_SSL_MAX_SESSION_SIZE];
  
  
 +int ngx_SSL_early_cb_fn (SSL *s, int *al, void *arg);
++void ngx_ssl_msg_callback(int write_p, int version, int content_type,
++    const void *buf, size_t len, SSL *ssl, void *arg);
++ngx_int_t ngx_ssl_parse_client_hello_extensions(ngx_connection_t *c);
 +
  #endif /* _NGX_EVENT_OPENSSL_H_INCLUDED_ */
 diff --git a/src/event/quic/ngx_event_quic_ssl.c b/src/event/quic/ngx_event_quic_ssl.c
-index daf2fe889..05f94f6ff 100644
+index ba0b5929f..3227d76ca 100644
 --- a/src/event/quic/ngx_event_quic_ssl.c
 +++ b/src/event/quic/ngx_event_quic_ssl.c
-@@ -412,6 +412,9 @@ ngx_quic_ssl_handshake(ngx_connection_t *c)
+@@ -407,6 +407,74 @@ ngx_quic_crypto_input(ngx_connection_t *c, ngx_chain_t *data,
+     for (cl = data; cl; cl = cl->next) {
+         b = cl->buf;
  
-     ssl_conn = c->ssl->connection;
++        // QUIC: Accumulate ClientHello from CRYPTO frames
++        // QUIC fragments large handshake messages across multiple CRYPTO frames
++        if (level == ssl_encryption_initial && !c->ssl->client_hello_parsed) {
++            const u_char *p = b->pos;
++            size_t len = b->last - b->pos;
++
++            if (len > 0) {
++                // Check if this is the start of a handshake message (type 1 = ClientHello)
++                if (c->ssl->raw_client_hello == NULL && len > 4 && p[0] == 1) {
++                    // Parse message length from first frame
++                    size_t msg_len = (p[1] << 16) | (p[2] << 8) | p[3];
++                    size_t total_len = 4 + msg_len;  // 1 byte type + 3 bytes length + message
++
++                    ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                                  "QUIC: Starting ClientHello capture, msg_len=%uz, total=%uz",
++                                  msg_len, total_len);
++
++                    // Allocate buffer for complete message
++                    c->ssl->raw_client_hello = ngx_pnalloc(c->pool, total_len);
++                    if (c->ssl->raw_client_hello != NULL) {
++                        c->ssl->raw_client_hello_len = 0;  // Track how much we've received
++                    }
++                }
++
++                // Append this frame's data
++                if (c->ssl->raw_client_hello != NULL) {
++                    // Get expected total length from the header
++                    if (c->ssl->raw_client_hello_len >= 4) {
++                        size_t expected_len = 4 + ((c->ssl->raw_client_hello[1] << 16) |
++                                                   (c->ssl->raw_client_hello[2] << 8) |
++                                                   c->ssl->raw_client_hello[3]);
++
++                        // Bounds check: ensure frame data doesn't overflow the allocated buffer
++                        // Even though allocation is based on header length, a malicious client
++                        // could send more data than the header claimed
++                        if (c->ssl->raw_client_hello_len + len > expected_len) {
++                            ngx_log_error(NGX_LOG_ALERT, c->log, 0,
++                                         "QUIC frame data (%uz bytes accumulated) exceeds "
++                                         "ClientHello header length (%uz bytes), truncating",
++                                         c->ssl->raw_client_hello_len + len, expected_len);
++                            // Truncate to prevent buffer overflow
++                            len = expected_len - c->ssl->raw_client_hello_len;
++                        }
++                    }
++
++                    // Only copy if we have valid data to copy
++                    if (len > 0) {
++                        ngx_memcpy(c->ssl->raw_client_hello + c->ssl->raw_client_hello_len, p, len);
++                        c->ssl->raw_client_hello_len += len;
++                    }
++
++                    // Check if we have the complete message
++                    if (c->ssl->raw_client_hello_len >= 4) {
++                        size_t expected_len = 4 + ((c->ssl->raw_client_hello[1] << 16) |
++                                                   (c->ssl->raw_client_hello[2] << 8) |
++                                                   c->ssl->raw_client_hello[3]);
++
++                        if (c->ssl->raw_client_hello_len >= expected_len) {
++                            c->ssl->client_hello_parsed = 1;
++                            ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
++                                          "QUIC: Complete ClientHello captured: %uz bytes",
++                                          c->ssl->raw_client_hello_len);
++                        }
++                    }
++                }
++            }
++        }
++
+         if (!SSL_provide_quic_data(ssl_conn, level, b->pos, b->last - b->pos)) {
+             ngx_ssl_error(NGX_LOG_INFO, c->log, 0,
+                           "SSL_provide_quic_data() failed");
+@@ -414,6 +482,9 @@ ngx_quic_crypto_input(ngx_connection_t *c, ngx_chain_t *data,
+         }
+     }
  
 +    /* ja4: Setting up a callback to collect TLS extensions */
 +    SSL_CTX_set_client_hello_cb (c->ssl->session_ctx, ngx_SSL_early_cb_fn, c);
@@ -178,20 +474,37 @@ index daf2fe889..05f94f6ff 100644
      n = SSL_do_handshake(ssl_conn);
  
      ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
+@@ -456,6 +527,11 @@ ngx_quic_crypto_input(ngx_connection_t *c, ngx_chain_t *data,
+ 
+     c->ssl->handshaked = 1;
+ 
++    // Parse raw ClientHello to get all extensions including ECH and ALPS (QUIC)
++    if (c->ssl->client_hello_parsed && c->ssl->extensions_sz == 0) {
++        ngx_ssl_parse_client_hello_extensions(c);
++    }
++
+     frame = ngx_quic_alloc_frame(c);
+     if (frame == NULL) {
+         return NGX_ERROR;
 diff --git a/src/http/modules/ngx_http_ssl_module.c b/src/http/modules/ngx_http_ssl_module.c
-index f7efc3a99..704744fa9 100644
+index 320d1ee04..7fbbe4f21 100644
 --- a/src/http/modules/ngx_http_ssl_module.c
 +++ b/src/http/modules/ngx_http_ssl_module.c
-@@ -466,6 +466,13 @@ ngx_http_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn, const unsigned char **out,
+@@ -440,6 +440,18 @@ ngx_http_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn, const unsigned char **out,
      ngx_connection_t        *c;
  
      c = ngx_ssl_get_connection(ssl_conn);
 +    // add first alpn value for ja4 to c->ssl
-+    if (c->ssl->first_alpn == NULL) {
-+        c->ssl->first_alpn = ngx_palloc(c->pool, in[0] + 1);
-+        // number of bytes for alpn is stored in in[0]
-+        ngx_memcpy(c->ssl->first_alpn, &in[1], in[0]);
-+        c->ssl->first_alpn[in[0]] = '\0';
++    if (c->ssl->first_alpn == NULL && inlen > 0) {
++        size_t alpn_len = in[0];
++        // bounds check: ensure buffer has enough data
++        if (alpn_len > 0 && inlen >= alpn_len + 1) {
++            c->ssl->first_alpn = ngx_palloc(c->pool, alpn_len + 1);
++            if (c->ssl->first_alpn != NULL) {
++                ngx_memcpy(c->ssl->first_alpn, &in[1], alpn_len);
++                c->ssl->first_alpn[alpn_len] = '\0';
++            }
++        }
 +    }
  #endif
  


### PR DESCRIPTION
Fix missing ECH and ALPS extensions 

- Replace SSL_client_hello_get1_extensions_present() with raw ClientHello parsing
- Capture all TLS extensions including ECH (0xfe0d) and ALPS (0x44cd)
- Add SCSV detection (TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
- Implement QUIC CRYPTO frame reassembly for fragmented ClientHello
- Support both TLS and QUIC connections with complete extension visibility

Patch generated from nginx 1.28.1 source code