### PR TITLE
move src/config to top-level config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !patches/
 !src/
+!config

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,14 @@ RUN wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
 RUN wget https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz && \
     tar -zxf openssl-${OPENSSL_VERSION}.tar.gz
 
-COPY src/config /tmp/ja4-nginx-module/src/config
+COPY config /tmp/ja4-nginx-module/config
 COPY src/ngx_http_ssl_ja4_module.c.dummy /tmp/ja4-nginx-module/src/ngx_http_ssl_ja4_module.c
 
 WORKDIR /tmp/nginx-${NGINX_VERSION}
 RUN ./configure \
       --with-openssl=/tmp/openssl-${OPENSSL_VERSION} \
       --with-debug --with-compat \
-      --add-module=/tmp/ja4-nginx-module/src \
+      --add-module=/tmp/ja4-nginx-module \
       --with-http_ssl_module \
       --with-http_v2_module \
       --with-http_v3_module \

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ To develop and debug the Dockerfile container, I find it useful to run docker wi
 
 ## Developer Guide
 
-Build against official nginx: apply `patches/nginx.patch` to the nginx source tree, then configure with `--add-module=/path/to/ja4-nginx-module/src`.
+Build against official nginx: apply `patches/nginx.patch` to the nginx source tree, then configure with `--add-module=/path/to/ja4-nginx-module`.
 
 ```bash
 cd nginx-${NGINX_VERSION}
 patch -p1 < /path/to/ja4-nginx-module/patches/nginx.patch
-./configure --add-module=/path/to/ja4-nginx-module/src --with-http_ssl_module ...
+./configure --add-module=/path/to/ja4-nginx-module --with-http_ssl_module ...
 make && make install
 ```
 

--- a/config
+++ b/config
@@ -1,4 +1,4 @@
 ngx_addon_name=ngx_http_ssl_ja4_module
 
 HTTP_MODULES="$HTTP_MODULES ngx_http_ssl_ja4_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_ssl_ja4_module.c"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_ssl_ja4_module.c"

--- a/config
+++ b/config
@@ -1,4 +1,11 @@
 ngx_addon_name=ngx_http_ssl_ja4_module
 
-HTTP_MODULES="$HTTP_MODULES ngx_http_ssl_ja4_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_ssl_ja4_module.c"
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=ngx_http_ssl_ja4_module
+    ngx_module_srcs="$ngx_addon_dir/src/ngx_http_ssl_ja4_module.c"
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_http_ssl_ja4_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_ssl_ja4_module.c"
+fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /tmp/nginx-${NGINX_VERSION}
 RUN patch -p1 < /tmp/ja4-nginx-module-${JA4_MODULE_VERSION}/patches/nginx.patch
 
 # Build Nginx
-RUN ./configure --with-openssl=/tmp/openssl-${OPENSSL_VERSION} --with-debug --with-compat --add-module=/tmp/ja4-nginx-module-${JA4_MODULE_VERSION}/src --with-http_ssl_module --prefix=/etc/nginx && \
+RUN ./configure --with-openssl=/tmp/openssl-${OPENSSL_VERSION} --with-debug --with-compat --add-module=/tmp/ja4-nginx-module-${JA4_MODULE_VERSION} --with-http_ssl_module --prefix=/etc/nginx && \
     make && \
     make install
 

--- a/docker/Dockerfile.quic
+++ b/docker/Dockerfile.quic
@@ -33,7 +33,7 @@ RUN wget https://github.com/FoxIO-LLC/ja4-nginx-module/releases/download/${VERSI
 RUN patch -p1 < ja4-nginx-module-${VERSION}/patches/nginx.patch
 
 # Build Nginx
-RUN ./configure --with-debug --with-compat --add-module=/tmp/nginx-${NGINX_VERSION}/ja4-nginx-module-${VERSION}/src --with-http_ssl_module --prefix=/etc/nginx && \
+RUN ./configure --with-debug --with-compat --add-module=/tmp/nginx-${NGINX_VERSION}/ja4-nginx-module-${VERSION} --with-http_ssl_module --prefix=/etc/nginx && \
     make && \
     make install
 


### PR DESCRIPTION
Nginx looks for config at the path given to --add-module. Pointing at the repo root previously failed because config only lived under src/.