### PR TITLE
test: add OpenResty-style Test::Nginx suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 .pytest_cache/
+
+# Test::Nginx runtime tree
+t/servroot/

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ __pycache__/
 .pytest_cache/
 
 # Test::Nginx runtime tree
-t/servroot/
+test/servroot/

--- a/README.md
+++ b/README.md
@@ -53,13 +53,12 @@ export PERL5LIB=$HOME/perl5/lib/perl5${PERL5LIB:+:$PERL5LIB}
 
 ```bash
 export TEST_NGINX_BINARY=/path/to/nginx   # binary built with this module
-export TEST_NGINX_SERVROOT=$PWD/test/servroot
 prove -v test/*.t
 # or a single file:
 prove -v test/plain-http-variables.t
 ```
 
-Test::Nginx writes its runtime tree to `t/servroot` unless `TEST_NGINX_SERVROOT` is set. The `.t` files default it to `test/servroot` so a bare `prove` does not recreate a top-level `t/` directory.
+`TEST_NGINX_SERVROOT` is optional. Each `.t` file defaults it to `test/servroot` so Test::Nginx does not write `t/servroot`. Set the variable only if you need a different path.
 
 **Dump the HTTP response on success**
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ There are two complementary suites:
 
 | Suite | Path | Framework | What it covers |
 |-------|------|-----------|----------------|
-| OpenResty-style | `t/` | [Test::Nginx](https://github.com/openresty/test-nginx) + `prove` | Module load, config/variables, plain-HTTP safety, JA4H (planned) |
-| Integration / TLS | `test/` | `pytest` + Docker | JA4 fingerprint goldens, ClientHello edge cases (curl, uTLS, curl_cffi) |
+| Test::Nginx | `test/*.t` | [Test::Nginx](https://github.com/openresty/test-nginx) + `prove` | Module load, config/variables, plain-HTTP safety, JA4H (planned) |
+| Integration / TLS | `test/*.py` | `pytest` + Docker | JA4 fingerprint goldens, ClientHello edge cases (curl, uTLS, curl_cffi) |
 
-### OpenResty-style tests (`t/`)
+### Test::Nginx tests (`test/*.t`)
 
-OpenResty-style cases live under `t/*.t`. Each case embeds a small nginx config, starts nginx, issues a request with the default Test::Nginx client (Perl `IO::Socket`, plain HTTP/1.1), and asserts on the response.
+Test::Nginx cases live under `test/*.t`. Each case embeds a small nginx config, starts nginx, issues a request with the default Test::Nginx client (Perl `IO::Socket`, plain HTTP/1.1), and asserts on the response.
 
 **Requirements**
 
@@ -53,24 +53,27 @@ export PERL5LIB=$HOME/perl5/lib/perl5${PERL5LIB:+:$PERL5LIB}
 
 ```bash
 export TEST_NGINX_BINARY=/path/to/nginx   # binary built with this module
-prove -v t/
+export TEST_NGINX_SERVROOT=$PWD/test/servroot
+prove -v test/*.t
 # or a single file:
-prove -v t/00-sanity.t
+prove -v test/plain-http-variables.t
 ```
+
+Test::Nginx writes its runtime tree to `t/servroot` unless `TEST_NGINX_SERVROOT` is set. The `.t` files default it to `test/servroot` so a bare `prove` does not recreate a top-level `t/` directory.
 
 **Dump the HTTP response on success**
 
 ```bash
-TEST_NGINX_VERBOSE=1 prove -v t/00-sanity.t
+TEST_NGINX_VERBOSE=1 prove -v test/plain-http-variables.t
 ```
 
 Current files:
 
-- `t/00-sanity.t` — module loads (`$http_ssl_ja4h`), SSL JA4 vars empty and safe on plain HTTP
+- `test/plain-http-variables.t` — module loads (`$http_ssl_ja4h`), SSL JA4 vars empty and safe on plain HTTP
 
-Runtime tree `t/servroot/` is created by Test::Nginx and is gitignored.
+Runtime tree `test/servroot/` is created by Test::Nginx and is gitignored.
 
-### Integration tests (`test/`)
+### Integration tests (`test/*.py`)
 
 Integration tests run against Docker and validate the module’s TLS fingerprinting against predefined scenarios using golden files in `test/testdata/`.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,52 @@ You can also build from source with:
 
 ## Testing
 
-Integration tests run inside Docker and validate the module’s behavior against predefined scenarios using golden files in `testdata/`.
+There are two complementary suites:
+
+| Suite | Path | Framework | What it covers |
+|-------|------|-----------|----------------|
+| OpenResty-style | `t/` | [Test::Nginx](https://github.com/openresty/test-nginx) + `prove` | Module load, config/variables, plain-HTTP safety, JA4H (planned) |
+| Integration / TLS | `test/` | `pytest` + Docker | JA4 fingerprint goldens, ClientHello edge cases (curl, uTLS, curl_cffi) |
+
+### OpenResty-style tests (`t/`)
+
+OpenResty-style cases live under `t/*.t`. Each case embeds a small nginx config, starts nginx, issues a request with the default Test::Nginx client (Perl `IO::Socket`, plain HTTP/1.1), and asserts on the response.
+
+**Requirements**
+
+- nginx built with this module (and the required core patch)
+- Perl modules: `Test::Nginx` (and dependencies)
+
+```bash
+# example: local install of Test::Nginx
+cpanm --local-lib=~/perl5 Test::Nginx
+export PERL5LIB=$HOME/perl5/lib/perl5${PERL5LIB:+:$PERL5LIB}
+```
+
+**Run**
+
+```bash
+export TEST_NGINX_BINARY=/path/to/nginx   # binary built with this module
+prove -v t/
+# or a single file:
+prove -v t/00-sanity.t
+```
+
+**Dump the HTTP response on success**
+
+```bash
+TEST_NGINX_VERBOSE=1 prove -v t/00-sanity.t
+```
+
+Current files:
+
+- `t/00-sanity.t` — module loads (`$http_ssl_ja4h`), SSL JA4 vars empty and safe on plain HTTP
+
+Runtime tree `t/servroot/` is created by Test::Nginx and is gitignored.
+
+### Integration tests (`test/`)
+
+Integration tests run against Docker and validate the module’s TLS fingerprinting against predefined scenarios using golden files in `test/testdata/`.
 
 Run tests:
 

--- a/t/00-sanity.t
+++ b/t/00-sanity.t
@@ -1,0 +1,63 @@
+# vi:filetype=perl
+# OpenResty-style sanity tests for ngx_http_ssl_ja4_module.
+#
+# Client: Test::Nginx default (Perl IO::Socket, plain HTTP/1.1).
+# Scope: module load, plain-HTTP safety when JA4 variables are referenced.
+# Not covered here: TLS ClientHello / JA4 golden fingerprints (see test/).
+#
+# Run (requires nginx built with this module + Test::Nginx):
+#   export TEST_NGINX_BINARY=/path/to/nginx
+#   export PERL5LIB=$HOME/perl5/lib/perl5${PERL5LIB:+:$PERL5LIB}
+#   prove -v t/00-sanity.t
+
+use Test::Nginx::Socket 'no_plan';
+
+repeat_each(1);
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: module_loads (JA4H variable is registered)
+# JA4H is HTTP-layer and works without TLS. A non-empty value proves the
+# module was compiled in and its variables are available to the rewrite
+# engine.
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+GET /t
+--- response_body_like chomp
+^ja4h=ge11nn
+
+
+
+=== TEST 2: plain_http_no_crash (SSL JA4 vars on plain HTTP)
+# On non-TLS connections ngx_ssl_ja4() declines; handlers must not crash
+# the worker. Current behavior substitutes an empty value (not 500).
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4=$http_ssl_ja4 ja4_string=$http_ssl_ja4_string ja4one=$http_ssl_ja4one ja4s=$http_ssl_ja4s ja4s_string=$http_ssl_ja4s_string ja4l=$http_ssl_ja4l\n";
+    }
+--- request
+GET /t
+--- response_body
+ja4= ja4_string= ja4one= ja4s= ja4s_string= ja4l=
+
+
+
+=== TEST 3: no_error_on_missing_ssl (mixed dump including JA4H)
+# Reference SSL + HTTP JA4 variables together on plain HTTP. SSL-derived
+# fields stay empty; JA4H is still computed from the request line/headers.
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4=$http_ssl_ja4 ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+GET /t
+--- response_body_like chomp
+^ja4= ja4h=ge11nn

--- a/test/plain-http-variables.t
+++ b/test/plain-http-variables.t
@@ -1,14 +1,20 @@
 # vi:filetype=perl
-# OpenResty-style sanity tests for ngx_http_ssl_ja4_module.
+# Test::Nginx tests for ngx_http_ssl_ja4_module.
 #
 # Client: Test::Nginx default (Perl IO::Socket, plain HTTP/1.1).
 # Scope: module load, plain-HTTP safety when JA4 variables are referenced.
-# Not covered here: TLS ClientHello / JA4 golden fingerprints (see test/).
+# Not covered here: TLS ClientHello / JA4 golden fingerprints (see test/*.py).
 #
 # Run (requires nginx built with this module + Test::Nginx):
 #   export TEST_NGINX_BINARY=/path/to/nginx
 #   export PERL5LIB=$HOME/perl5/lib/perl5${PERL5LIB:+:$PERL5LIB}
-#   prove -v t/00-sanity.t
+#   export TEST_NGINX_SERVROOT=$PWD/test/servroot
+#   prove -v test/plain-http-variables.t
+
+BEGIN {
+    use File::Spec;
+    $ENV{TEST_NGINX_SERVROOT} ||= File::Spec->rel2abs('test/servroot');
+}
 
 use Test::Nginx::Socket 'no_plan';
 

--- a/test/plain-http-variables.t
+++ b/test/plain-http-variables.t
@@ -8,8 +8,8 @@
 # Run (requires nginx built with this module + Test::Nginx):
 #   export TEST_NGINX_BINARY=/path/to/nginx
 #   export PERL5LIB=$HOME/perl5/lib/perl5${PERL5LIB:+:$PERL5LIB}
-#   export TEST_NGINX_SERVROOT=$PWD/test/servroot
 #   prove -v test/plain-http-variables.t
+# TEST_NGINX_SERVROOT is optional; defaults to test/servroot below.
 
 BEGIN {
     use File::Spec;


### PR DESCRIPTION
## Summary

Adds a first OpenResty-style test under `t/` using Test::Nginx, alongside the existing pytest suite in `test/`.

`t/00-sanity.t` covers:

- module loads (`$http_ssl_ja4h` available)
- SSL JA4 vars are empty and safe on plain HTTP

This is a starting point only — we can add more cases under `t/` (variables, JA4H, headers/logging) the same way. TLS fingerprint goldens stay in `test/`.

## Run

```bash
export TEST_NGINX_BINARY=/path/to/nginx
prove -v t/00-sanity.t

Discussion

Is this direction welcome? If so, happy to grow t/ further while keeping pytest for ClientHello-heavy tests.