### PR TITLE
fix: align JA4H with FoxIO header list, hash12, and cookie pairs

### DIFF
--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -1191,13 +1191,27 @@ ngx_ssl_ja4h_push_cookie(ngx_pool_t *pool, ngx_array_t *list,
     return NGX_OK;
 }
 
+/* FoxIO / Wireshark sort by cookie name, not the full name=value pair.
+ * Cookie: a-b=1; a=2 must become a,a-b (not a-b,a): '-' sorts before '='. */
 static int ngx_libc_cdecl
 ngx_ssl_ja4h_cmp_cookie(const void *one, const void *two)
 {
     const ngx_ssl_ja4h_cookie_t *a = one;
     const ngx_ssl_ja4h_cookie_t *b = two;
+    size_t n;
+    int rc;
 
-    return compare_ngx_str(&a->pair, &b->pair);
+    n = ngx_min(a->name_len, b->name_len);
+    rc = ngx_strncmp(a->pair.data, b->pair.data, n);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (a->name_len == b->name_len) {
+        return 0;
+    }
+
+    return a->name_len < b->name_len ? -1 : 1;
 }
 
 // JA4H

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -1233,9 +1233,9 @@ ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h)
     ngx_memset(ja4h->http_method, 0, 3);
     ngx_strlow((u_char *) ja4h->http_method, (u_char *) r->method_name.data, 2);
 
-    ngx_memset(ja4h->http_version, 0, 3);
-    ngx_snprintf((u_char *) ja4h->http_version, 2, "%d%d",
-                 r->http_version / 1000, r->http_version % 1000);
+    ja4h->http_version[0] = (char) ('0' + r->http_version / 1000);
+    ja4h->http_version[1] = (char) ('0' + r->http_version % 1000);
+    ja4h->http_version[2] = '\0';
 
     ja4h->cookie_presence = r->headers_in.cookie ? 'c' : 'n';
     ja4h->referrer_presence = r->headers_in.referer ? 'r' : 'n';

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -7,6 +7,11 @@
 #include <stdint.h>
 #include "ngx_http_ssl_ja4_module.h"
 
+static void ngx_ssl_ja4h_fp(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h,
+    ngx_str_t *out);
+static void ngx_ssl_ja4h_fp_string(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h,
+    ngx_str_t *out);
+
 /**
  * This is a list of Nginx variables that will be registered with Nginx.
  * The `ngx_http_add_variable` function will be used to register each
@@ -1099,14 +1104,114 @@ ngx_http_ssl_ja4x_string(ngx_http_request_t *r,
 }
 void ngx_ssl_ja4x_fp_string(ngx_pool_t *pool, ngx_ssl_ja4x_t *ja4x, ngx_str_t *out) {}
 
-// JA4H
-int ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h)
+// Cookie and Referer are recorded only as a-flags; omit them from the header-name list.
+static ngx_int_t
+ngx_ssl_ja4h_is_cookie_or_referer(ngx_table_elt_t *h)
 {
-    ngx_str_t *entry;
+    if (h->key.len == sizeof("Cookie") - 1
+        && ngx_strncasecmp(h->key.data, (u_char *) "Cookie", sizeof("Cookie") - 1) == 0)
+    {
+        return 1;
+    }
+
+    if (h->key.len == sizeof("Referer") - 1
+        && ngx_strncasecmp(h->key.data, (u_char *) "Referer", sizeof("Referer") - 1) == 0)
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+/* FoxIO hash12: 12 hex chars of SHA-256; empty input is 000000000000, not SHA256(""). */
+static ngx_int_t
+ngx_ssl_ja4h_hash12(ngx_str_t *in, char *out)
+{
+    SHA256_CTX sha256;
+    u_char hash[SHA256_DIGEST_LENGTH];
     size_t i;
 
+    ngx_memzero(out, 13);
+
+    if (in->len == 0) {
+        ngx_memcpy(out, "000000000000", 12);
+        return NGX_OK;
+    }
+
+    if (SHA256_Init(&sha256) != 1) {
+        return NGX_DECLINED;
+    }
+    SHA256_Update(&sha256, in->data, in->len);
+    SHA256_Final(hash, &sha256);
+
+    for (i = 0; i < 6; i++) {
+        ngx_sprintf((u_char *) &out[i * 2], "%02xd", hash[i]);
+    }
+
+    return NGX_OK;
+}
+
+typedef struct {
+    ngx_str_t pair;
+    size_t    name_len;
+} ngx_ssl_ja4h_cookie_t;
+
+static ngx_int_t
+ngx_ssl_ja4h_push_cookie(ngx_pool_t *pool, ngx_array_t *list,
+    u_char *start, u_char *end, size_t *fields_len, size_t *pairs_len)
+{
+    ngx_ssl_ja4h_cookie_t *item;
+    u_char *eq;
+
+    while (start < end && isspace(*start)) {
+        start++;
+    }
+
+    item = ngx_array_push(list);
+    if (item == NULL) {
+        return NGX_ERROR;
+    }
+
+    item->pair.len = end - start;
+    item->pair.data = ngx_pcalloc(pool, item->pair.len + 1);
+    if (item->pair.data == NULL) {
+        return NGX_ERROR;
+    }
+    ngx_memcpy(item->pair.data, start, item->pair.len);
+
+    eq = ngx_strlchr(item->pair.data, item->pair.data + item->pair.len, '=');
+    if (eq != NULL) {
+        item->name_len = eq - item->pair.data;
+    } else {
+        item->name_len = item->pair.len;
+    }
+
+    *fields_len += item->name_len + 1;
+    *pairs_len += item->pair.len + 1;
+    return NGX_OK;
+}
+
+static int ngx_libc_cdecl
+ngx_ssl_ja4h_cmp_cookie(const void *one, const void *two)
+{
+    const ngx_ssl_ja4h_cookie_t *a = one;
+    const ngx_ssl_ja4h_cookie_t *b = two;
+
+    return compare_ngx_str(&a->pair, &b->pair);
+}
+
+// JA4H
+int
+ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h)
+{
+    ngx_ssl_ja4h_cookie_t *cookie;
+    size_t i;
+
+    ngx_memzero(ja4h, sizeof(ngx_ssl_ja4h_t));
+
     if (r->method_name.len < 2) {
-        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0, "JA4H failed: Unknown request method");
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "JA4H failed: Unknown request method");
         return NGX_DECLINED;
     }
 
@@ -1115,30 +1220,22 @@ int ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h)
     ngx_strlow((u_char *) ja4h->http_method, (u_char *) r->method_name.data, 2);
 
     ngx_memset(ja4h->http_version, 0, 3);
-    ngx_snprintf((u_char *) ja4h->http_version, 2, "%d%d", r->http_version / 1000, r->http_version % 1000);
+    ngx_snprintf((u_char *) ja4h->http_version, 2, "%d%d",
+                 r->http_version / 1000, r->http_version % 1000);
 
     ja4h->cookie_presence = r->headers_in.cookie ? 'c' : 'n';
     ja4h->referrer_presence = r->headers_in.referer ? 'r' : 'n';
 
-    ngx_memset(ja4h->num_headers, 0, 3);
-    ngx_snprintf((u_char *) ja4h->num_headers, 2, "%02d", r->headers_in.headers.part.nelts - (r->headers_in.cookie ? 1 : 0) - (r->headers_in.referer ? 1 : 0));
-
+    // First 4 Accept-Language chars: skip '-', stop at ',' or ';', lowercased.
+    // Missing or short values stay/pad as 0000.
     ngx_memcpy(ja4h->primary_accept_language, "0000", 5);
 
-    // JA4H_b
-    SHA256_CTX sha256;
-    unsigned char hash_result[SHA256_DIGEST_LENGTH];
-    memset(hash_result, 0, SHA256_DIGEST_LENGTH);
-
-    if (SHA256_Init(&sha256) != 1) {
-        return NGX_DECLINED;
-    }
-
+    // JA4H_b: comma-joined header names with Cookie/Referer dropped, then hash that buffer.
     ngx_list_part_t *headers_part = &r->headers_in.headers.part;
     ngx_table_elt_t *header_item = headers_part->elts;
 
+    ngx_uint_t n_headers = 0;
     size_t raw_http_headers_len = 0;
-    // Count the total length of all header key separated by a ','
     for (i = 0; /* void */; i++) {
         if (i >= headers_part->nelts) {
             if (headers_part->next == NULL){
@@ -1148,202 +1245,167 @@ int ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h)
             header_item = headers_part->elts;
             i = 0;
         }
-        raw_http_headers_len += header_item[i].key.len + 1;
-    }
-
-    // Allocate memory for the raw_http_headers
-    ja4h->raw_http_headers = ngx_pcalloc(pool, raw_http_headers_len + 1);
-    if (ja4h->raw_http_headers == NULL) {
-        return NGX_ERROR;
-    }
-
-    headers_part = &r->headers_in.headers.part;
-    header_item = headers_part->elts;
-    u_char *current = NULL;
-    for (i = 0; /* void */; i++) {
-        if (i >= headers_part->nelts) {
-            if (headers_part->next == NULL){
-                break;
-            }
-            headers_part = headers_part->next;
-            header_item = headers_part->elts;
-            i = 0;
-        }
-
         if ((ja4h->primary_accept_language[0] == '0')
             && (header_item[i].key.len == sizeof("Accept-Language") - 1)
-            && (ngx_strncasecmp(header_item[i].key.data, (u_char *) "Accept-Language", sizeof("Accept-Language") - 1) == 0)) {
+            && (ngx_strncasecmp(header_item[i].key.data, (u_char *) "Accept-Language",
+                                sizeof("Accept-Language") - 1) == 0))
+        {
             size_t idx, c;
-            // Get the first 4 character of primary Accept-Language
-            for( c=0, idx=0; idx < 4; c++ ) {
+
+            for (c = 0, idx = 0; idx < 4 && c < header_item[i].value.len; c++) {
                 if (header_item[i].value.data[c] == '-') {
                     continue;
                 } else if (header_item[i].value.data[c] == ','
-                    || header_item[i].value.data[c] == ';'
-                    || header_item[i].value.data[c] == '\0') {
+                           || header_item[i].value.data[c] == ';')
+                {
                     break;
                 }
-                ja4h->primary_accept_language[idx++] = ngx_tolower(header_item[i].value.data[c]);
+                ja4h->primary_accept_language[idx++] =
+                    ngx_tolower(header_item[i].value.data[c]);
             }
         }
-        if (current == NULL) {
-            current = (u_char *) ja4h->raw_http_headers;
-        } else {
+
+        if (ngx_ssl_ja4h_is_cookie_or_referer(&header_item[i])) {
+            continue;
+        }
+        raw_http_headers_len += header_item[i].key.len + 1;
+        n_headers++;
+    }
+
+    if (n_headers > 99) {
+        n_headers = 99;
+    }
+    ja4h->num_headers[0] = (char) ('0' + n_headers / 10);
+    ja4h->num_headers[1] = (char) ('0' + n_headers % 10);
+    ja4h->num_headers[2] = '\0';
+
+    ja4h->raw_http_headers.data = ngx_pcalloc(pool, raw_http_headers_len + 1);
+    if (ja4h->raw_http_headers.data == NULL) {
+        return NGX_ERROR;
+    }
+    ja4h->raw_http_headers.len = 0;
+
+    headers_part = &r->headers_in.headers.part;
+    header_item = headers_part->elts;
+    u_char *current = ja4h->raw_http_headers.data;
+    for (i = 0; /* void */; i++) {
+        if (i >= headers_part->nelts) {
+            if (headers_part->next == NULL){
+                break;
+            }
+            headers_part = headers_part->next;
+            header_item = headers_part->elts;
+            i = 0;
+        }
+
+        if (ngx_ssl_ja4h_is_cookie_or_referer(&header_item[i])) {
+            continue;
+        }
+
+        if (current != ja4h->raw_http_headers.data) {
             *current++ = ',';
         }
         ngx_memcpy(current, header_item[i].key.data, header_item[i].key.len);
         current += header_item[i].key.len;
-        SHA256_Update(&sha256, header_item[i].key.data, header_item[i].key.len);
     }
-    SHA256_Final(hash_result, &sha256);
+    ja4h->raw_http_headers.len = current - ja4h->raw_http_headers.data;
 
-    // Convert the first 6 bytes of hash to hex for JA4H_b
-    ngx_memset(ja4h->http_header_hash, 0, 13);
-    for (i = 0; i < 6; i++) {
-        sprintf(&ja4h->http_header_hash[i * 2], "%02x", hash_result[i]);
+    if (ngx_ssl_ja4h_hash12(&ja4h->raw_http_headers, ja4h->http_header_hash)
+        != NGX_OK)
+    {
+        return NGX_DECLINED;
     }
 
     // JA4H_c_d
     size_t raw_cookie_fields_len = 0;
-    size_t raw_cookie_values_len = 0;
+    size_t raw_cookie_pairs_len = 0;
 
-    ngx_array_t *cookie_key_list = ngx_array_create(pool, 10, sizeof(ngx_str_t));
-    if (cookie_key_list == NULL) {
-        return NGX_ERROR;
-    }
-    ngx_array_t *cookie_key_value_list = ngx_array_create(pool, 10, sizeof(ngx_str_t));
-    if (cookie_key_value_list == NULL) {
+    ngx_array_t *cookie_list = ngx_array_create(pool, 10, sizeof(ngx_ssl_ja4h_cookie_t));
+    if (cookie_list == NULL) {
         return NGX_ERROR;
     }
 
-    // Parse cookies value assignment
     ngx_table_elt_t *req_header_cookie;
 
-    for(req_header_cookie = r->headers_in.cookie; req_header_cookie; req_header_cookie = req_header_cookie->next) {
-        ngx_str_t *item;
-        u_char *start, *end, *assignment;
-        size_t key_len, value_len;
+    for (req_header_cookie = r->headers_in.cookie;
+         req_header_cookie;
+         req_header_cookie = req_header_cookie->next)
+    {
+        u_char *start, *end, *p;
 
         start = req_header_cookie->value.data;
         end = start + req_header_cookie->value.len;
-        for (current = start; current <= end; current++) {
-            if (*current == ';' || current == end) {
-                for(; *start && isspace(*start) && start < end; start++);
-                item = (ngx_str_t *) ngx_array_push(cookie_key_value_list);
-                if (item == NULL) {
+        for (p = start; p < end; p++) {
+            if (*p == ';') {
+                if (ngx_ssl_ja4h_push_cookie(pool, cookie_list, start, p,
+                                             &raw_cookie_fields_len,
+                                             &raw_cookie_pairs_len)
+                    != NGX_OK)
+                {
                     return NGX_ERROR;
                 }
-                item->len = current - start;
-                item->data = ngx_pcalloc(pool, item->len + 1);
-                if (item->data == NULL) {
-                    return NGX_ERROR;
-                }
-                ngx_memcpy(item->data, start, item->len);
-                start = current + 1;
-                assignment = (u_char *) strchr((char *) item->data, '=');
-                if (assignment != NULL) {
-                    key_len = assignment - item->data;
-                } else {
-                    key_len = item->len;
-                }
-                value_len = item->len - key_len - 1;
-                raw_cookie_fields_len += key_len + 1;
-                raw_cookie_values_len += value_len + 1;
+                start = p + 1;
             }
         }
-    }
-
-    // Sort the Cookie Fields + Value for JA4H
-    ngx_qsort(cookie_key_value_list->elts, cookie_key_value_list->nelts, sizeof(ngx_str_t), compare_ngx_str);
-
-    unsigned char hash_result_fields[SHA256_DIGEST_LENGTH];
-    unsigned char hash_result_fields_values[SHA256_DIGEST_LENGTH];
-    SHA256_CTX sha256_fields;
-    SHA256_CTX sha256_fields_values;
-
-    memset(hash_result_fields, 0, SHA256_DIGEST_LENGTH);
-    memset(hash_result_fields_values, 0, SHA256_DIGEST_LENGTH);
-
-    if (SHA256_Init(&sha256_fields) != 1) {
-        return NGX_DECLINED;
-    }
-    if (SHA256_Init(&sha256_fields_values) != 1) {
-        return NGX_DECLINED;
-    }
-
-    ja4h->raw_cookie_fields = ngx_pcalloc(pool, raw_cookie_fields_len + 1);
-    if (ja4h->raw_cookie_fields == NULL) {
-        return NGX_ERROR;
-    }
-    ja4h->raw_cookie_values = ngx_pcalloc(pool, raw_cookie_values_len + 1);
-    if (ja4h->raw_cookie_values == NULL) {
-        return NGX_ERROR;
-    }
-
-    u_char *current_raw_cookie_field, *current_raw_cookie_value;
-    size_t key_len, value_len;
-
-    current_raw_cookie_field = (u_char *) ja4h->raw_cookie_fields;
-    current_raw_cookie_value = (u_char *) ja4h->raw_cookie_values;
-
-    for (i = 0; i < cookie_key_value_list->nelts; i++) {
-        u_char *value, *assignment;
-        entry = (ngx_str_t *) cookie_key_value_list->elts + i;
-        SHA256_Update(&sha256_fields_values, entry->data, entry->len);
-        assignment = (u_char *) strchr((char *) entry->data, '=');
-        if (assignment != NULL) {
-            value = assignment + 1;
-            // Split key value assignment into two strings
-            *assignment = '\0';
-            key_len = assignment - entry->data;
-            value_len = entry->len - key_len - 1;
-        } else {
-            key_len = entry->len;
-            value_len = 0;
-            value = NULL;
+        if (ngx_ssl_ja4h_push_cookie(pool, cookie_list, start, end,
+                                     &raw_cookie_fields_len,
+                                     &raw_cookie_pairs_len)
+            != NGX_OK)
+        {
+            return NGX_ERROR;
         }
+    }
 
-        SHA256_Update(&sha256_fields, entry->data, entry->len);
+    ngx_qsort(cookie_list->elts, cookie_list->nelts,
+              sizeof(ngx_ssl_ja4h_cookie_t), ngx_ssl_ja4h_cmp_cookie);
 
-        // Copy the key to the raw_cookie_fields
-        if (current_raw_cookie_field != (u_char *) ja4h->raw_cookie_fields) {
-            // Add comma separator if not the first entry
+    ja4h->raw_cookie_fields.data = ngx_pcalloc(pool, raw_cookie_fields_len + 1);
+    if (ja4h->raw_cookie_fields.data == NULL) {
+        return NGX_ERROR;
+    }
+    ja4h->raw_cookie_pairs.data = ngx_pcalloc(pool, raw_cookie_pairs_len + 1);
+    if (ja4h->raw_cookie_pairs.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    u_char *current_raw_cookie_field, *current_raw_cookie_pair;
+
+    current_raw_cookie_field = ja4h->raw_cookie_fields.data;
+    current_raw_cookie_pair = ja4h->raw_cookie_pairs.data;
+
+    for (i = 0; i < cookie_list->nelts; i++) {
+        cookie = &((ngx_ssl_ja4h_cookie_t *) cookie_list->elts)[i];
+
+        if (current_raw_cookie_pair != ja4h->raw_cookie_pairs.data) {
+            *current_raw_cookie_pair++ = ',';
+        }
+        ngx_memcpy(current_raw_cookie_pair, cookie->pair.data, cookie->pair.len);
+        current_raw_cookie_pair += cookie->pair.len;
+
+        if (current_raw_cookie_field != ja4h->raw_cookie_fields.data) {
             *current_raw_cookie_field++ = ',';
         }
-        ngx_memcpy(current_raw_cookie_field, entry->data, key_len);
-        current_raw_cookie_field += key_len;
-
-        if (value != NULL) {
-            // Copy the value to the raw_cookie_values
-            if (current_raw_cookie_value != (u_char *) ja4h->raw_cookie_values) {
-                // Add comma separator if not the first entry
-                *current_raw_cookie_value++ = ',';
-            }
-            ngx_memcpy(current_raw_cookie_value, value, value_len);
-            current_raw_cookie_value += value_len;
-        }
-        if (assignment != NULL) {
-            // Restore original key value assignment string
-            *assignment = '=';
-        }
+        ngx_memcpy(current_raw_cookie_field, cookie->pair.data, cookie->name_len);
+        current_raw_cookie_field += cookie->name_len;
     }
-    SHA256_Final(hash_result_fields, &sha256_fields);
-    SHA256_Final(hash_result_fields_values, &sha256_fields_values);
+    ja4h->raw_cookie_fields.len = current_raw_cookie_field - ja4h->raw_cookie_fields.data;
+    ja4h->raw_cookie_pairs.len = current_raw_cookie_pair - ja4h->raw_cookie_pairs.data;
 
-    // Convert the first 6 bytes of hash to hex for JA4H_c
-    ngx_memset(ja4h->cookie_field_hash, 0, 13);
-    for (i = 0; i < 6; i++) {
-        sprintf(&ja4h->cookie_field_hash[i * 2], "%02x", hash_result_fields[i]);
+    if (ngx_ssl_ja4h_hash12(&ja4h->raw_cookie_fields, ja4h->cookie_field_hash)
+        != NGX_OK)
+    {
+        return NGX_DECLINED;
     }
 
-    // Convert the first 6 bytes of hash to hex for JA4H_d
-    ngx_memset(ja4h->cookie_value_hash, 0, 13);
-    for (i = 0; i < 6; i++) {
-        sprintf(&ja4h->cookie_value_hash[i * 2], "%02x", hash_result_fields_values[i]);
+    if (ngx_ssl_ja4h_hash12(&ja4h->raw_cookie_pairs, ja4h->cookie_value_hash)
+        != NGX_OK)
+    {
+        return NGX_DECLINED;
     }
 
     return NGX_OK;
 }
+
 static ngx_int_t
 ngx_http_ssl_ja4h(ngx_http_request_t *r,
                   ngx_http_variable_value_t *v, uintptr_t data)
@@ -1356,7 +1418,7 @@ ngx_http_ssl_ja4h(ngx_http_request_t *r,
         return NGX_OK;
     }
 
-    if (ngx_ssl_ja4h(r, r->pool, &ja4h) == NGX_DECLINED)
+    if (ngx_ssl_ja4h(r, r->pool, &ja4h) != NGX_OK)
     {
         return NGX_ERROR;
     }
@@ -1371,7 +1433,10 @@ ngx_http_ssl_ja4h(ngx_http_request_t *r,
 
     return NGX_OK;
 }
-void ngx_ssl_ja4h_fp(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *out) {
+
+static void
+ngx_ssl_ja4h_fp(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *out)
+{
     out->data = ngx_pnalloc(pool, JA4H_FINGERPRINT_LENGTH + 1);
     if (out->data == NULL)
     {
@@ -1388,6 +1453,7 @@ void ngx_ssl_ja4h_fp(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *out) {
         ja4h->cookie_value_hash);
     out->len = ngx_strlen(out->data);
 }
+
 // JA4H STRING
 static ngx_int_t
 ngx_http_ssl_ja4h_string(ngx_http_request_t *r,
@@ -1401,7 +1467,7 @@ ngx_http_ssl_ja4h_string(ngx_http_request_t *r,
         return NGX_OK;
     }
 
-    if (ngx_ssl_ja4h(r, r->pool, &ja4h) == NGX_DECLINED)
+    if (ngx_ssl_ja4h(r, r->pool, &ja4h) != NGX_OK)
     {
         return NGX_ERROR;
     }
@@ -1416,10 +1482,16 @@ ngx_http_ssl_ja4h_string(ngx_http_request_t *r,
 
     return NGX_OK;
 }
-void ngx_ssl_ja4h_fp_string(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *out) {
+
+static void
+ngx_ssl_ja4h_fp_string(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *out)
+{
     u_char *current;
     size_t len;
-    len = JA4H_A_FINGERPRINT_LENGTH + 1 + ngx_strlen(ja4h->raw_http_headers) + 1 + ngx_strlen(ja4h->raw_cookie_fields) + 1 + ngx_strlen(ja4h->raw_cookie_values);
+    len = JA4H_A_FINGERPRINT_LENGTH + 1
+        + ja4h->raw_http_headers.len + 1
+        + ja4h->raw_cookie_fields.len + 1
+        + ja4h->raw_cookie_pairs.len;
     out->data = ngx_pnalloc(pool, len + 1);
     if (out->data == NULL)
     {
@@ -1435,17 +1507,17 @@ void ngx_ssl_ja4h_fp_string(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *o
         ja4h->num_headers, ja4h->primary_accept_language);
     current += JA4H_A_FINGERPRINT_LENGTH;
     *current++ = '_';
-    ngx_memcpy(current, ja4h->raw_http_headers, ngx_strlen(ja4h->raw_http_headers));
-    current += ngx_strlen(ja4h->raw_http_headers);
+    ngx_memcpy(current, ja4h->raw_http_headers.data, ja4h->raw_http_headers.len);
+    current += ja4h->raw_http_headers.len;
     *current++ = '_';
-    ngx_memcpy(current, ja4h->raw_cookie_fields, ngx_strlen(ja4h->raw_cookie_fields));
-    current += ngx_strlen(ja4h->raw_cookie_fields);
+    ngx_memcpy(current, ja4h->raw_cookie_fields.data, ja4h->raw_cookie_fields.len);
+    current += ja4h->raw_cookie_fields.len;
     *current++ = '_';
-    ngx_memcpy(current, ja4h->raw_cookie_values, ngx_strlen(ja4h->raw_cookie_values));
-    current += ngx_strlen(ja4h->raw_cookie_values);
+    ngx_memcpy(current, ja4h->raw_cookie_pairs.data, ja4h->raw_cookie_pairs.len);
+    current += ja4h->raw_cookie_pairs.len;
     *current = '\0';
 
-    out->len = ngx_strlen(out->data);
+    out->len = current - out->data;
 }
 
 // JA4T

--- a/src/ngx_http_ssl_ja4_module.h
+++ b/src/ngx_http_ssl_ja4_module.h
@@ -86,9 +86,9 @@ typedef struct ngx_ssl_ja4h_s
     char cookie_value_hash[13]; // 12 characters for truncated sha256 hash of cookie fields+values + null terminator
 
     // Raw data fields for the -r and -o options
-    char *raw_http_headers;  // Dynamically allocated string for raw HTTP headers
-    char *raw_cookie_fields; // Dynamically allocated string for raw cookie fields
-    char *raw_cookie_values; // Dynamically allocated string for raw cookie field values
+    ngx_str_t raw_http_headers;  // comma-joined header names, Cookie/Referer dropped
+    ngx_str_t raw_cookie_fields; // comma-joined cookie names, sorted
+    ngx_str_t raw_cookie_pairs;  // comma-joined cookie name=value pairs, sorted
 } ngx_ssl_ja4h_t;
 
 typedef struct ngx_ssl_ja4t_s
@@ -417,10 +417,8 @@ static ngx_int_t ngx_http_ssl_ja4s_string(ngx_http_request_t *r, ngx_http_variab
 
 // JA4H
 int ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h);
-void ngx_ssl_ja4h_fp(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *out);
 static ngx_int_t ngx_http_ssl_ja4h(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 // JA4H STRING
-void ngx_ssl_ja4h_fp_string(ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h, ngx_str_t *out);
 static ngx_int_t ngx_http_ssl_ja4h_string(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 
 // JA4T

--- a/src/ngx_http_ssl_ja4_module.h
+++ b/src/ngx_http_ssl_ja4_module.h
@@ -241,13 +241,6 @@ static int compare_hexes(const void *a, const void *b)
     return 0;
 }
 
-static int ngx_libc_cdecl compare_ngx_str(const void *one, const void *two)
-{
-    ngx_str_t *a = (ngx_str_t *) one;
-    ngx_str_t *b = (ngx_str_t *) two;
-    return ngx_strncasecmp(a->data, b->data, a->len);
-}
-
 #if (NGX_DEBUG)
 static void
 ngx_ssl_ja4l_detail_print(ngx_pool_t *pool, ngx_ssl_ja4l_t *ja4l)

--- a/test/plain-http-variables.t
+++ b/test/plain-http-variables.t
@@ -454,3 +454,40 @@ GET /t
 ^ja4h=ge11nn210000_e46fbdfb6ecf_000000000000_000000000000$
 --- no_error_log
 [error]
+
+
+
+=== TEST 24: ja4h_string_cookie_name_prefix_sort
+# Sort by cookie name, not the full pair. Cookie: a-b=1; a=2
+# Pair-sort would emit a-b,a because '-' < '='; name-sort emits a,a-b.
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h_string=$http_ssl_ja4h_string\n";
+    }
+--- more_headers
+Cookie: a-b=1; a=2
+--- request
+GET /t
+--- response_body_like chomp
+^ja4h_string=ge11cn020000_Host,Connection_a,a-b_a=2,a-b=1$
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: ja4h_spec_cookie_name_prefix_sort
+# Same cookies as TEST 24, hashed: hash12("a,a-b") / hash12("a=2,a-b=1").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- more_headers
+Cookie: a-b=1; a=2
+--- request
+GET /t
+--- response_body_like chomp
+^ja4h=ge11cn020000_d5c75abc5c2c_474f0429a83d_8777147329fe$
+--- no_error_log
+[error]

--- a/test/testdata/ech_alps.txt
+++ b/test/testdata/ech_alps.txt
@@ -9,7 +9,7 @@
 
             JA4S String: 
 
-            JA4H: ge11nn14enus_33ac871f7c5e_e3b0c44298fc_e3b0c44298fc
+            JA4H: ge11nn14enus_4a2973d235de_000000000000_000000000000
 
             JA4H String: ge11nn14enus_Host,sec-ch-ua,sec-ch-ua-mobile,sec-ch-ua-platform,Upgrade-Insecure-Requests,User-Agent,Accept,Sec-Fetch-Site,Sec-Fetch-Mode,Sec-Fetch-User,Sec-Fetch-Dest,Accept-Encoding,Accept-Language,Priority__
 

--- a/test/testdata/no_sni_ip.txt
+++ b/test/testdata/no_sni_ip.txt
@@ -9,7 +9,7 @@
 
             JA4S String: 
 
-            JA4H: ge11nn030000_b51846f30ce9_e3b0c44298fc_e3b0c44298fc
+            JA4H: ge11nn030000_fe444ad14866_000000000000_000000000000
 
             JA4H String: ge11nn030000_Host,User-Agent,Accept__
 

--- a/test/testdata/tls12_h11.txt
+++ b/test/testdata/tls12_h11.txt
@@ -9,7 +9,7 @@
 
             JA4S String: 
 
-            JA4H: ge11nn030000_b51846f30ce9_e3b0c44298fc_e3b0c44298fc
+            JA4H: ge11nn030000_fe444ad14866_000000000000_000000000000
 
             JA4H String: ge11nn030000_Host,User-Agent,Accept__
 

--- a/test/testdata/tls13_h2.txt
+++ b/test/testdata/tls13_h2.txt
@@ -9,7 +9,7 @@
 
             JA4S String: 
 
-            JA4H: ge11nn030000_b51846f30ce9_e3b0c44298fc_e3b0c44298fc
+            JA4H: ge11nn030000_fe444ad14866_000000000000_000000000000
 
             JA4H String: ge11nn030000_Host,User-Agent,Accept__
 


### PR DESCRIPTION
Drop Cookie/Referer from the header-name list used for count, hashed b, and JA4H_r. Hash b/c/d from the finished comma-joined ngx_str_t buffers (hash12 empty is 12 zeros). JA4H_r cookie d is sorted name=value pairs.

Scan cookies and Accept-Language by value length, store cookie name_len once, and fail JA4H variables on any non-NGX_OK from ngx_ssl_ja4h.