### PR TITLE
map JA4H methods with FoxIO codes

### DIFF
--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -1217,6 +1217,81 @@ ngx_ssl_ja4h_cmp_cookie(const void *one, const void *two)
     return a->name_len < b->name_len ? -1 : 1;
 }
 
+/* FoxIO JA4H method codes (Wireshark packet-ja4.c http_method_map).
+ * Unknown methods that still parse (e.g. FOO) use "00". */
+static const struct {
+    ngx_str_t  method;
+    u_char     code[2];
+} ngx_ssl_ja4h_method_map[] = {
+    { ngx_string("ACL"),               { 'a', 'c' } },
+    { ngx_string("BASELINE-CONTROL"),  { 'b', 'a' } },
+    { ngx_string("BIND"),              { 'b', 'i' } },
+    { ngx_string("CHECKIN"),           { 'c', 'n' } },
+    { ngx_string("CHECKOUT"),          { 'c', 't' } },
+    { ngx_string("CONNECT"),           { 'c', 'o' } },
+    { ngx_string("COPY"),              { 'c', 'y' } },
+    { ngx_string("DELETE"),            { 'd', 'e' } },
+    { ngx_string("GET"),               { 'g', 'e' } },
+    { ngx_string("HEAD"),              { 'h', 'e' } },
+    { ngx_string("LABEL"),             { 'l', 'a' } },
+    { ngx_string("LINK"),              { 'l', 'i' } },
+    { ngx_string("LOCK"),              { 'l', 'o' } },
+    { ngx_string("MERGE"),             { 'm', 'e' } },
+    { ngx_string("MKACTIVITY"),        { 'm', 'a' } },
+    { ngx_string("MKCALENDAR"),        { 'm', 'c' } },
+    { ngx_string("MKCOL"),             { 'm', 'l' } },
+    { ngx_string("MKREDIRECTREF"),     { 'm', 'r' } },
+    { ngx_string("MKWORKSPACE"),       { 'm', 'w' } },
+    { ngx_string("MOVE"),              { 'm', 'o' } },
+    { ngx_string("M-SEARCH"),          { 'm', 's' } },
+    { ngx_string("NOTIFY"),            { 'n', 'o' } },
+    { ngx_string("OPTIONS"),           { 'o', 'p' } },
+    { ngx_string("PATCH"),             { 'p', 'a' } },
+    { ngx_string("POST"),              { 'p', 'o' } },
+    { ngx_string("PRI"),               { 'p', 'r' } },
+    { ngx_string("PROPFIND"),          { 'p', 'f' } },
+    { ngx_string("PROPPATCH"),         { 'p', 'p' } },
+    { ngx_string("PURGE"),             { 'p', 'r' } },
+    { ngx_string("PUT"),               { 'p', 'u' } },
+    { ngx_string("REBIND"),            { 'r', 'b' } },
+    { ngx_string("REPORT"),            { 'r', 'p' } },
+    { ngx_string("SEARCH"),            { 's', 'e' } },
+    { ngx_string("SUBSCRIBE"),         { 's', 'u' } },
+    { ngx_string("TRACE"),             { 't', 'r' } },
+    { ngx_string("UNBIND"),            { 'u', 'b' } },
+    { ngx_string("UNCHECKOUT"),        { 'u', 'c' } },
+    { ngx_string("UNLINK"),            { 'u', 'i' } },
+    { ngx_string("UNLOCK"),            { 'u', 'o' } },
+    { ngx_string("UNSUBSCRIBE"),       { 'u', 'n' } },
+    { ngx_string("UPDATE"),            { 'u', 'p' } },
+    { ngx_string("UPDATEREDIRECTREF"), { 'u', 'r' } },
+    { ngx_string("VERSION-CONTROL"),   { 'v', 'e' } },
+};
+
+static void
+ngx_ssl_ja4h_method_code(ngx_str_t *method_name, char *out)
+{
+    size_t  i;
+
+    out[0] = '0';
+    out[1] = '0';
+    out[2] = '\0';
+
+    for (i = 0; i < sizeof(ngx_ssl_ja4h_method_map)
+                    / sizeof(ngx_ssl_ja4h_method_map[0]); i++)
+    {
+        if (method_name->len == ngx_ssl_ja4h_method_map[i].method.len
+            && ngx_strncasecmp(method_name->data,
+                               ngx_ssl_ja4h_method_map[i].method.data,
+                               method_name->len) == 0)
+        {
+            out[0] = ngx_ssl_ja4h_method_map[i].code[0];
+            out[1] = ngx_ssl_ja4h_method_map[i].code[1];
+            return;
+        }
+    }
+}
+
 // JA4H
 int
 ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h)
@@ -1226,15 +1301,8 @@ ngx_ssl_ja4h(ngx_http_request_t *r, ngx_pool_t *pool, ngx_ssl_ja4h_t *ja4h)
 
     ngx_memzero(ja4h, sizeof(ngx_ssl_ja4h_t));
 
-    if (r->method_name.len < 2) {
-        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                      "JA4H failed: Unknown request method");
-        return NGX_DECLINED;
-    }
-
     // JA4H_a
-    ngx_memset(ja4h->http_method, 0, 3);
-    ngx_strlow((u_char *) ja4h->http_method, (u_char *) r->method_name.data, 2);
+    ngx_ssl_ja4h_method_code(&r->method_name, ja4h->http_method);
 
     ja4h->http_version[0] = (char) ('0' + r->http_version / 1000);
     ja4h->http_version[1] = (char) ('0' + r->http_version % 1000);

--- a/src/ngx_http_ssl_ja4_module.c
+++ b/src/ngx_http_ssl_ja4_module.c
@@ -137,8 +137,11 @@ int ngx_ssl_ja4(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja4_t *ja4)
     if (!ssl) {
         return NGX_DECLINED;
     }
-
+#if (NGX_QUIC || NGX_COMPAT)
     ja4->transport = (c->quic) ? 'q' : 't';
+#else
+    ja4->transport = 't';
+#endif
     ja4->has_sni = SSL_get_servername (ssl, TLSEXT_NAMETYPE_host_name) ? 'd' : 'i';
     ja4->alpn_first_value = c->ssl->first_alpn;
 

--- a/test/plain-http-variables.t
+++ b/test/plain-http-variables.t
@@ -4,7 +4,8 @@
 # Client: Test::Nginx default (Perl IO::Socket, plain HTTP/1.1).
 # Scope: module load, plain-HTTP safety when JA4 variables are referenced,
 #        JA4H HTTP-layer fields (method, Cookie, Referer, Accept-Language),
-#        JA4H goldens from FoxIO rust/ja4/src/http.rs (comma-join, hash12 zeros).
+#        JA4H goldens from FoxIO rust/ja4/src/http.rs (comma-join, hash12 zeros)
+#        and FoxIO Wireshark packet-ja4.c http_method_map (method codes).
 # Not covered here: TLS ClientHello / JA4 golden fingerprints (see test/*.py).
 #
 # Run (requires nginx built with this module + Test::Nginx):
@@ -136,7 +137,7 @@ GET /t
 
 
 === TEST 7: ja4h_post
-# First two letters of POST, lowercased. Do not pin header count:
+# JA4H method map: POST -> po. Do not pin header count:
 # Test::Nginx may add Content-Length for the body.
 --- config
     location /t {
@@ -489,5 +490,278 @@ Cookie: a-b=1; a=2
 GET /t
 --- response_body_like chomp
 ^ja4h=ge11cn020000_d5c75abc5c2c_474f0429a83d_8777147329fe$
+--- no_error_log
+[error]
+
+
+
+=== TEST 26: ja4h_msearch
+# JA4H map: M-SEARCH -> ms (not first two chars "m-"). Nginx parses
+# hyphenated methods as NGX_HTTP_UNKNOWN; lookup uses method_name.
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+M-SEARCH /t
+--- response_body_like chomp
+^ja4h=ms11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 27: ja4h_unknown_method
+# Unknown but legal method FOO -> 00 (not first two chars "fo").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+FOO /t
+--- response_body_like chomp
+^ja4h=0011nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 28: ja4h_mkcol
+# JA4H map: MKCOL -> ml (not first two chars "mk").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+MKCOL /t
+--- response_body_like chomp
+^ja4h=ml11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 29: ja4h_copy
+# JA4H map: COPY -> cy (not first two chars "co").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+COPY /t
+--- response_body_like chomp
+^ja4h=cy11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 30: ja4h_purge
+# JA4H map: PURGE -> pr (not "pu"; PUT is pu).
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+PURGE /t
+--- response_body_like chomp
+^ja4h=pr11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: ja4h_propfind
+# JA4H map: PROPFIND -> pf (not "pr").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+PROPFIND /t
+--- response_body_like chomp
+^ja4h=pf11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 32: ja4h_proppatch
+# JA4H map: PROPPATCH -> pp (not "pr").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+PROPPATCH /t
+--- response_body_like chomp
+^ja4h=pp11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 33: ja4h_checkin
+# JA4H map: CHECKIN -> cn (not "ch").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+CHECKIN /t
+--- response_body_like chomp
+^ja4h=cn11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 34: ja4h_checkout
+# JA4H map: CHECKOUT -> ct (not "ch").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+CHECKOUT /t
+--- response_body_like chomp
+^ja4h=ct11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 35: ja4h_report
+# JA4H map: REPORT -> rp (not "re").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+REPORT /t
+--- response_body_like chomp
+^ja4h=rp11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 36: ja4h_unlock
+# JA4H map: UNLOCK -> uo (not "un").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+UNLOCK /t
+--- response_body_like chomp
+^ja4h=uo11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 37: ja4h_unlink
+# JA4H map: UNLINK -> ui (not "un").
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+UNLINK /t
+--- response_body_like chomp
+^ja4h=ui11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 38: ja4h_mkactivity
+# JA4H map: MKACTIVITY -> ma (not "mk"; MKCOL is ml).
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+MKACTIVITY /t
+--- response_body_like chomp
+^ja4h=ma11nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 39: ja4h_unknown_one_char
+# One-character method is parseable; must emit 00, not decline the fingerprint.
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+A /t
+--- response_body_like chomp
+^ja4h=0011nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 40: ja4h_unknown_prefix
+# GETS must not match GET by prefix.
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+GETS /t
+--- response_body_like chomp
+^ja4h=0011nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 41: ja4h_unknown_hyphen
+# FOO-BAR is parseable (hyphen allowed) but not in the map; 00 not "fo".
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+FOO-BAR /t
+--- response_body_like chomp
+^ja4h=0011nn
+--- no_error_log
+[error]
+
+
+
+=== TEST 42: ja4h_unknown_underscore
+# Underscore is parseable; FOO_BAR is not in the map.
+--- config
+    location /t {
+        default_type text/plain;
+        return 200 "ja4h=$http_ssl_ja4h\n";
+    }
+--- request
+FOO_BAR /t
+--- response_body_like chomp
+^ja4h=0011nn
 --- no_error_log
 [error]


### PR DESCRIPTION
Use the Wireshark http_method_map instead of the first two letters of the verb. 
Unknown but parseable methods fingerprint as 00.